### PR TITLE
Add Django dev server recipe to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 up:
-	docker compose up -d
+	docker compose -f docker-compose.yml -f docker-compose-local.yml run --rm --service-ports web
+
+up-devserver:
+	docker compose -f docker-compose.yml -f docker-compose-local.yml run --rm --service-ports --entrypoint "python manage.py runserver 0.0.0.0:8000" web
 
 down:
 	docker compose down

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,5 @@
+services:
+  web:
+    depends_on:
+      init:
+        condition: service_completed_successfully


### PR DESCRIPTION
Enable the application to be easily run using the Django dev server because it respects breakpoints (gunicorn doesn't).

Change the 'up' recipe so it is consistent (uses docker compose RUN) with the new recipe. This makes the dependency on the init container explicit.