### PR TITLE
FormView to reduce boilerplate and other cleanup

### DIFF
--- a/request_a_govuk_domain/request/forms.py
+++ b/request_a_govuk_domain/request/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.core.validators import EmailValidator
 from django.template.defaultfilters import filesizeformat
 from django.conf import settings
 
@@ -49,6 +50,7 @@ class EmailForm(forms.Form):
         label="Email",
         help_text="Enter your email address.",
         widget=forms.EmailInput,
+        validators=[EmailValidator("Please enter a valid email address")],
     )
 
     def __init__(self, *args, **kwargs):

--- a/request_a_govuk_domain/request/forms.py
+++ b/request_a_govuk_domain/request/forms.py
@@ -16,13 +16,27 @@ from .base_form import FormWithLabelStyle
 from .utils import organisations_list
 
 
-class NameForm(FormWithLabelStyle):
+class NameForm(forms.Form):
     """
-    Example form, please modify/ remove this when the actual requirements are clear
-    This is only created to test the ui with gov uk design is working
+    Example form
+    This is an example of Crispy forms with govuk design system
+    https://github.com/wildfish/crispy-forms-gds
     """
-    registrant_full_name = forms.CharField(label='Registrant Full Name', max_length=100,
-                                           widget=forms.TextInput(attrs={"class": "govuk-input"}))
+    registrant_full_name = forms.CharField(
+        label="Registrant Full Name",
+        help_text="Enter your name as it appears on your passport.",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.label_size = Size.SMALL
+        self.helper.layout = Layout(
+            Fieldset(
+                Field.text("registrant_full_name"),
+            ),
+            Button("submit", "Continue"),
+        )
 
 
 class EmailForm(forms.Form):
@@ -48,17 +62,9 @@ class EmailForm(forms.Form):
             Button("submit", "Continue"),
         )
 
-    def clean_registrant_email_address(self):
-        """
-        Example custom validation for email address
-        Checks that the email address ends with .gov.uk
-        """
-        registrant_email_address = self.cleaned_data.get('registrant_email_address')
 
-        if not registrant_email_address.endswith('.gov.uk'):
-            raise forms.ValidationError("Email address must end with .gov.uk")
-
-        return registrant_email_address
+class ConfirmForm(forms.Form):
+    pass
 
 
 class ExemptionForm(forms.Form):

--- a/request_a_govuk_domain/request/templates/name.html
+++ b/request_a_govuk_domain/request/templates/name.html
@@ -1,17 +1,8 @@
 {% extends "base.html" %}
-
+{% load crispy_forms_tags crispy_forms_gds %}
 {% block main %}
 
-    {% load govuk_frontend_django %}
-
-    {% gds_component "back-link" href="/name" %}
-
-    <h1 class="govuk-heading-xl">Name</h1>
-
-    <form method="post" action="{% url 'name' %}">
-        {% csrf_token %}
-        {{ form.as_p }}
-        {% gds_component "button" text="Save" %}
-    </form>
+    {% error_summary form %}
+    {% crispy form %}
 
 {% endblock %}

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -1,11 +1,14 @@
 from django.shortcuts import render, redirect
+from django.urls import reverse_lazy
+from django.views.generic import TemplateView
 from django.views import View
 from .forms import (
     NameForm,
     EmailForm,
     ExemptionForm,
     ExemptionUploadForm,
-    RegistrarForm
+    RegistrarForm,
+    ConfirmForm,
 )
 from .models import RegistrationData
 from django.views.generic.edit import FormView
@@ -18,63 +21,58 @@ All views are example views, please modify remove as needed
 """
 
 
-class NameView(View):
+class NameView(FormView):
     template_name = 'name.html'
+    form_class = NameForm
+    success_url = reverse_lazy('email')
 
-    def get(self, request):
-        form = NameForm()
-        return render(request, self.template_name, {'form': form})
-
-    def post(self, request):
-        form = NameForm(request.POST)
-        if form.is_valid():
-            request.session['registration_data'] = {'registrant_full_name': form.cleaned_data['registrant_full_name']}
-            return redirect('email')
-        return render(request, self.template_name, {'form': form})
+    def form_valid(self, form):
+        self.request.session['registration_data'] = {'registrant_full_name': form.cleaned_data['registrant_full_name']}
+        return super().form_valid(form)
 
 
-class EmailView(View):
+class EmailView(FormView):
     template_name = 'email.html'
+    form_class = EmailForm
+    success_url = reverse_lazy('confirm')
 
-    def get(self, request):
-        form = EmailForm()
-        return render(request, self.template_name, {'form': form})
-
-    def post(self, request):
-        form = EmailForm(request.POST)
-        if form.is_valid():
-            registration_data = request.session.get('registration_data', {})
-            registration_data['registrant_email_address'] = form.cleaned_data['registrant_email_address']
-            request.session['registration_data'] = registration_data
-            return redirect('confirm')
-        return render(request, self.template_name, {'form': form})
+    def form_valid(self, form):
+        registration_data = self.request.session.get('registration_data', {})
+        registration_data['registrant_email_address'] = form.cleaned_data['registrant_email_address']
+        self.request.session['registration_data'] = registration_data
+        return super().form_valid(form)
 
 
-class ConfirmView(View):
+class ConfirmView(FormView):
     template_name = 'confirm.html'
+    form_class = ConfirmForm
+    success_url = reverse_lazy('success')
 
-    def get(self, request):
-        registration_data = request.session.get('registration_data', {})
-        return render(request, self.template_name, {'registration_data': registration_data})
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
 
-    def post(self, request):
-        registration_data = request.session.get('registration_data', {})
+        # Access session data and include it in the context
+        registration_data = self.request.session.get('registration_data', {})
+        context['registration_data'] = registration_data
+
+        return context
+
+    def form_valid(self, form):
+        registration_data = self.request.session.get('registration_data', {})
 
         # Save data to the database
         RegistrationData.objects.create(registrant_full_name=registration_data['registrant_full_name'],
                                         registrant_email_address=registration_data['registrant_email_address'])
 
         # Clear session data after saving
-        request.session.pop('registration_data', None)
+        self.request.session.pop('registration_data', None)
 
-        return redirect('success')
+        return super().form_valid(form)
 
 
-class SuccessView(View):
+class SuccessView(TemplateView):
     template_name = 'success.html'
 
-    def get(self, request):
-        return render(request, self.template_name, {})
 
 
 class ExemptionView(FormView):


### PR DESCRIPTION
FormView will remove the need for get, post method boilerplate code

The view will only contain the business logic that it needs to

Other cleanups:

Changed the NameForm from subclassing FormWithLabelStyle

to subclassing forms.Form. This will help in removing base_form.py

which we won't be needing anymore

name.html is now based on crispy_forms_gds

Removed the R&D custom validation logic of checking that email

must end with .gov.uk