### PR TITLE
Check that we're following the flow correctly

### DIFF
--- a/cypress/e2e/no-email.cy.js
+++ b/cypress/e2e/no-email.cy.js
@@ -1,6 +1,10 @@
 describe('Check if user entered an email', () => {
   it('Complains when no email is entered', () => {
-    cy.visit('http://0.0.0.0:8000/email/')
+    cy.visit('http://0.0.0.0:8000/')
+
+    cy.get('h1').should('include.text', 'Which .gov.uk Approved Registrar organisation are you from?')
+    cy.get('select.govuk-select').select('34SP.com')
+    cy.get('.govuk-button').click()
 
     // Don't type anything, just click on the button
     cy.get('.govuk-button').click()

--- a/cypress/e2e/progress-error.cy.js
+++ b/cypress/e2e/progress-error.cy.js
@@ -1,0 +1,40 @@
+describe('Don\'t allow breaking the flow', () => {
+
+  it('Sends you to the start if you join in the middle', () => {
+    cy.visit('http://0.0.0.0:8000/registrant_type_fail')
+
+    cy.get('h1').should('include.text', 'Which .gov.uk Approved Registrar organisation are you from?')
+    cy.url().should('be.equal', 'http://0.0.0.0:8000/')
+  })
+
+
+  it('Sends you to the start if you post data with no CSRF token', () => {
+    cy.visit({
+        url: "http://0.0.0.0:8000/email",
+        method: "POST",
+        body: {
+          registrant_email_address: "example@example.com"
+          // No CSRF token
+        }
+    });
+
+    cy.get('h1').should('include.text', 'Which .gov.uk Approved Registrar organisation are you from?')
+    cy.url().should('be.equal', 'http://0.0.0.0:8000/')
+  })
+
+
+  it('Sends you to the start if you post data with a random CSRF token', () => {
+    cy.visit({
+        url: "http://0.0.0.0:8000/email",
+        method: "POST",
+        body: {
+          registrant_email_address: "example@example.com",
+          csrfmiddlewaretoken: "eLqwO7i5BCusJsqUD7EWkkGKSt8Ztu63X8Lkf0x5OF8a3xAh8Dpr0joJsuELlX0i" # pragma: allowlist secret
+        }
+    });
+
+    cy.get('h1').should('include.text', 'Which .gov.uk Approved Registrar organisation are you from?')
+    cy.url().should('be.equal', 'http://0.0.0.0:8000/')
+  })
+
+})

--- a/request_a_govuk_domain/request/middleware.py
+++ b/request_a_govuk_domain/request/middleware.py
@@ -1,0 +1,31 @@
+from django.shortcuts import redirect
+from django.urls import reverse
+
+
+class FormProgressMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if request.path != reverse("start") and not self.is_valid_progress(request):
+            return redirect("start")  # Redirect to start page if progress is invalid
+        return response
+
+    def is_valid_progress(self, request):
+        if request.session.get("registration_data") is None:
+            print("FALSE: no reg data")
+            return False
+        for key in request.session.get("registration_data"):
+            if key not in [
+                "registrant_type",
+                "registrant_full_name",
+                "registrant_email_address",
+                "registrar_organisation",
+            ]:
+                # A key in the session data is invalid. So go back to the beginning
+                request.session["registration_data"] = {}
+                print("FALSE: unknown reg data:", key)
+                return False
+        print("TRUE")
+        return True

--- a/request_a_govuk_domain/settings.py
+++ b/request_a_govuk_domain/settings.py
@@ -66,6 +66,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "request_a_govuk_domain.request.middleware.FormProgressMiddleware",
 ]
 
 FILE_UPLOAD_HANDLERS = [

--- a/request_a_govuk_domain/urls.py
+++ b/request_a_govuk_domain/urls.py
@@ -33,7 +33,7 @@ from .request.views import (
 )
 
 urlpatterns = [
-    path("", RegistrarView.as_view(), name="registrar"),
+    path("", RegistrarView.as_view(), name="start"),
     path("admin/", admin.site.urls),
     path("name/", NameView.as_view(), name="name"),
     path("email/", EmailView.as_view(), name="email"),


### PR DESCRIPTION
- if the user joins one of the intermediary URLs without having the data needed, send them to the start
- if the (malicious user) attempts to POST data at any point without having followed the flow, as checked by the CSRF token, send them to the start.