### PR TITLE
Re-enable access to Django admin site

### DIFF
--- a/request_a_govuk_domain/request/middleware.py
+++ b/request_a_govuk_domain/request/middleware.py
@@ -8,9 +8,18 @@ class FormProgressMiddleware:
 
     def __call__(self, request):
         response = self.get_response(request)
-        if request.path != reverse("start") and not self.is_valid_progress(request):
-            return redirect("start")  # Redirect to start page if progress is invalid
-        return response
+        if self.is_valid_start_path(request.path):
+            return response
+        if self.is_valid_progress(request):
+            return response
+        return redirect("start")  # Redirect to start page if progress is invalid
+
+    def is_valid_start_path(self, path: str):
+        if path == reverse("start"):
+            return True
+        if path.startswith("/admin"):
+            return True
+        return False
 
     def is_valid_progress(self, request):
         if request.session.get("registration_data") is None:


### PR DESCRIPTION
The middleware to prevent people starting the user journey part way through was a bit strict. This adds an exception to the redirect condition for the admin site.

We use startswith rather than the literal path because attempting to access "/admin" immediately redirects to "/admin/login...".