### PR TITLE
Prevent init container failing when DB is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,6 @@ Alternatively, you can use `make up-devserver` to use the Django development ser
 
 When the application is run, any migrations are applied to the database. Seed data for the `reviewer` user group (see below) is also applied.
 
-When running the application for the first time, or after deleting the docker volume containing the database, it's typical for docker to throw the following error:
-
-```
-service "init" didn't completed successfully: exit 1
-make: *** [Makefile:5: up-devserver] Error 1
-```
-
 Just run either `make up` or `make up-devserver` again.
 
 ## Usage instructions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       <<: *common-application-variables
     depends_on:
       postgres:
-        condition: service_started
+          condition: service_healthy
 
   postgres:
     platform: linux/amd64
@@ -46,6 +46,11 @@ services:
       POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   init:
     <<: *api-base
@@ -54,7 +59,8 @@ services:
       <<: *common-application-variables
     command: [ "sh", "-c", "python manage.py migrate --noinput && python manage.py loaddata ./seed/reviewer_group.json ./seed/users.json ./seed/request.json" ]
     depends_on:
-      - postgres
+      postgres:
+          condition: service_healthy
 
 
 volumes:


### PR DESCRIPTION
It's common for the init container to fail when cloning the repo for the frst time or after deleting the postgres docker volume. This is because it takes postgres a few seconds to initialise the database and it isn't ready when the init container runs.

This ensure that the init container waits for the postgres container to be ready, rather than simply running, before starting. Also added to the web container.