### PR TITLE
Simplify Docker and Docker Compose files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,31 +2,31 @@ FROM public.ecr.aws/docker/library/python:3.10
 
 ARG POETRY_ARGS="--no-root --no-ansi --only main"
 
-WORKDIR /srv/request_a_govuk_domain
+RUN useradd -u 1000 govuk_domain
 
-RUN pip install poetry gunicorn \
-  && useradd -u 1000 govuk_domain
+RUN pip install poetry gunicorn
 
-COPY pyproject.toml poetry.lock /srv/request_a_govuk_domain/
+COPY pyproject.toml poetry.lock /app/
 
-RUN poetry config virtualenvs.create false \
-  && poetry install ${POETRY_ARGS}
+WORKDIR /app
 
-COPY manage.py /srv/request_a_govuk_domain/
-COPY request_a_govuk_domain /srv/request_a_govuk_domain/request_a_govuk_domain
+RUN poetry config virtualenvs.create false && \
+    poetry install ${POETRY_ARGS}
 
-RUN sed -i 's/\r$//' /srv/request_a_govuk_domain/manage.py  && \
-        chmod +x /srv/request_a_govuk_domain/manage.py
+COPY manage.py /app/
+COPY request_a_govuk_domain /app/request_a_govuk_domain
 
-RUN SECRET_KEY=unneeded /srv/request_a_govuk_domain/manage.py collectstatic --no-input
+RUN sed -i 's/\r$//' /app/manage.py  && \
+    chmod +x /app/manage.py
 
-RUN mkdir /var/run/request_a_govuk_domain \
-  && chown govuk_domain:govuk_domain /var/run/request_a_govuk_domain
+RUN SECRET_KEY=unneeded /app/manage.py collectstatic --no-input
+
+RUN mkdir /var/run/request_a_govuk_domain && \
+    chown govuk_domain:govuk_domain /var/run/request_a_govuk_domain
 
 RUN mkdir /home/govuk_domain && \
     chown govuk_domain:govuk_domain /home/govuk_domain
 
 USER govuk_domain
-
 
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -20,25 +20,21 @@ Steps to run the project locally on docker:
 1. Clone the repository
 2. Go to the project directory: domains-register-a-govuk-domain
 3. Ensure docker is running on your machine
-4. Run the following command to run the application:
-```bash
-make collectstatic; make up
-```
+4. Run one of the following commands to run the application:
 
-The command `make collectstatic` is to collect the static files and `make up` is to run the application on docker.
+- Using gunicorn:
+    ```bash
+    make up
+    ```
+- Using the Django development server:
+    ```bash
+    make up-devserver
+    ```
 
-`make collectstatic` is a one-time command to collect the static files. It is not required to run this command every time, unless there are changes in the static files.
-
-So after the first time, the command to run the application on local docker is:
-```bash
-make up
-```
-
-Alternatively, you can use `make up-devserver` to use the Django development server in place of gunicorn.
-
-When the application is run, any migrations are applied to the database. Seed data for the `reviewer` user group (see below) is also applied.
-
-Just run either `make up` or `make up-devserver` again.
+When the application is run:
+- Any migrations are applied to the database.
+- Static files collected.
+- Seed data (see below) is also applied if it doesn't already exist.
 
 ## Usage instructions
 

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,5 +1,0 @@
-services:
-  web:
-    depends_on:
-      init:
-        condition: service_completed_successfully

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,19 +11,13 @@ x-api-base: &api-base
     args:
       POETRY_ARGS: "--no-root --no-ansi"
   volumes:
-    - .:/srv/request_a_govuk_domain
+    - .:/app
 
 services:
 
   web:
     platform: linux/amd64
-    build:
-      context: .
-      args:
-        POETRY_ARGS: "--no-root --no-ansi"
-    volumes:
-      - ./request_a_govuk_domain:/srv/request_a_govuk_domain/request_a_govuk_domain
-      - govuk_domain_home:/home/govuk_domain
+    <<: *api-base
     ports:
       - "8000:8000"
     #Added the reload flag so the application will be reloaded when the source is modified.
@@ -33,6 +27,8 @@ services:
     depends_on:
       postgres:
           condition: service_healthy
+      init:
+        condition: service_completed_successfully
 
   postgres:
     platform: linux/amd64
@@ -57,7 +53,7 @@ services:
     restart: 'no'
     environment:
       <<: *common-application-variables
-    command: [ "sh", "-c", "python manage.py migrate --noinput && python manage.py loaddata ./seed/reviewer_group.json ./seed/users.json ./seed/request.json" ]
+    command: [ "sh", "/app/local-init.sh" ]
     depends_on:
       postgres:
           condition: service_healthy


### PR DESCRIPTION
For the time being we don't need two docker-compose files. Simplify and re-order the Dockerfile (mostly to simplify the container's internal directory structure).

Add a local-init.sh script which is not copied into the app image but run in the init container via a bind mount. In addition to the tasks previously carried out by the init container (migrate, seed), this runs collectstatic. There's now no longer a need to do this explicitly.

Remove references to deleted docker compose file in Makefile.

Update the README to reflect the above.