### PR TITLE
Don't override get_fields in custom ModelAdmins

### DIFF
--- a/request_a_govuk_domain/request/admin.py
+++ b/request_a_govuk_domain/request/admin.py
@@ -47,9 +47,6 @@ class ReviewerReadOnlyFieldsMixin:
             if isinstance(field, FileField)
         ]
 
-    def get_fields(self, request, obj=None):
-        return self._get_field_names()
-
     def get_urls(self):
         urls = super().get_urls()
         all_fields = []


### PR DESCRIPTION
This was causing the admin site to crash when logged in as a superuser. It's not needed in any case as we want superusers to be able to edit applications, including changing the file associated with each of the evidence fields, if need be.