### PR TITLE
Treat datetime fields as readonly

### DIFF
--- a/request_a_govuk_domain/request/admin.py
+++ b/request_a_govuk_domain/request/admin.py
@@ -34,7 +34,9 @@ class ReviewerReadOnlyFieldsMixin:
         if request.user.is_superuser:
             return []
         else:
-            return self._get_field_names(not request.user.is_superuser)
+            return self._get_field_names(not request.user.is_superuser) + [
+                "time_decided"
+            ]
 
     def get_fields(self, request, obj=None):
         return self._get_field_names(not request.user.is_superuser)
@@ -189,6 +191,9 @@ class ApplicationAdmin(ReviewerReadOnlyFieldsMixin, admin.ModelAdmin):
     download_written_permission_evidence.short_description = (
         "Written permission evidence"
     )
+
+    def get_readonly_fields(self, request, obj=None):
+        return super().get_readonly_fields(request, obj) + ["time_submitted"]
 
 
 admin.site.unregister(User)


### PR DESCRIPTION
The built-in Django admin interface handles the auto-generated time_submitted field properly. However the django-grappelli and django-admin-interface packages, which were tested as quick ways of making the admin site a bit nicer to work with, throw an exception every time an application is loaded. This fixes that by explicitly treating time_sumitted as readonly.

The time_decided field should be readonly for reviewer users, so this is done too.