### PR TITLE
Get NOTIFY_API_KEY from environment variable

### DIFF
--- a/request_a_govuk_domain/request/utils.py
+++ b/request_a_govuk_domain/request/utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import uuid
 from typing import List
@@ -8,6 +9,8 @@ from django.core.exceptions import ValidationError
 import clamd
 from dotenv import load_dotenv
 from notifications_python_client import NotificationsAPIClient
+
+logger = logging.getLogger(__name__)
 
 # Load environment values from .env file
 load_dotenv()
@@ -157,11 +160,14 @@ def send_email(email_address: str, template_id: str, personalisation: dict) -> N
     param: template_id: Template id of the Email Template
     param: personalisation: Dictionary of Personalisation data
     """
-    # TODO Change this to get notify_api_key from aws later on
     notify_api_key = get_env_variable("NOTIFY_API_KEY")
-    notifications_client = NotificationsAPIClient(notify_api_key)
-    notifications_client.send_email_notification(
-        email_address=email_address,
-        template_id=template_id,
-        personalisation=personalisation,
-    )
+    # If api key is found then send email, else log that it was not found
+    if notify_api_key:
+        notifications_client = NotificationsAPIClient(notify_api_key)
+        notifications_client.send_email_notification(
+            email_address=email_address,
+            template_id=template_id,
+            personalisation=personalisation,
+        )
+    else:
+        logger.info("Not sending email as Notify API key not found")

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -31,7 +31,6 @@ from .utils import (
     remove_from_session,
     route_number,
     send_email,
-    get_env_variable,
 )
 
 
@@ -399,8 +398,7 @@ class SuccessView(View):
     def get(self, request):
         reference = generate_reference()
         save_data_in_database(reference, request)
-        if get_env_variable("SEND_EMAIL", "False") == "True":
-            send_confirmation_email(request)
+        send_confirmation_email(request)
 
         # We're finished, so clear the session data
         request.session.pop("registration_data", None)


### PR DESCRIPTION
This will allow the NOTIFY_API_KEY to be provided from AWS, which will be made available as the env variable NOTIFY_API_KEY

If the NOTIFY_API_KEY is available then it will send email, else just log that NOTIFY_API_KEY is not found.

This is still taking care of the happy scenario only. Error scenarios will be taken care in further PR.

Removed SEND_EMAIL flag as that is not needed.