### PR TITLE
Make cypress testing logs less verbose

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -84,7 +84,7 @@ jobs:
         DATABASE_URL: postgresql://govuk_domain:govuk_domain@localhost:5432/govuk_domain
       with:
         start: |
-          poetry run ./manage.py runserver 0.0.0.0:8010 --verbosity 0 --noreload
+          /home/runner/work/domains-register-a-govuk-domain/domains-register-a-govuk-domain/.github/workflows/start-server.sh
     - name: Run Unit Tests
       env:
         DATABASE_URL: postgresql://govuk_domain:govuk_domain@localhost:5432/govuk_domain

--- a/.github/workflows/start-server.sh
+++ b/.github/workflows/start-server.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 echo "Starting test server"
-export SECRET_KEY=blah
-export DATABASE_URL=postgresql://govuk_domain:govuk_domain@localhost:5432/gov
-poetry run ./manage.py runserver 0.0.0.0:8010 > /dev/null
+poetry run ./manage.py runserver 0.0.0.0:8010 >/dev/null 2>&1


### PR DESCRIPTION
The cypress part of our Github Actions generates a lot of logs, since the test server outputs one line per http request. We only want the cypress output so this change silences the server.