### PR TITLE
Don't mandate permission for rejecting a review

### DIFF
--- a/request_a_govuk_domain/request/models/review.py
+++ b/request_a_govuk_domain/request/models/review.py
@@ -67,7 +67,6 @@ class Review(models.Model):
                 self.registrant_org_exists,
                 self.registrant_org_eligible,
                 self.registrant_person_id_confirmed,
-                self.permission_signatory_role_confirmed,
                 self.domain_name_validated,
             )
         ):


### PR DESCRIPTION
Some applications don't have need permission (e.g. Parish council) so we don't enforce it before allowing the admin user to reject.