### PR TITLE
Send Approval/Rejection email from the admin site

### DIFF
--- a/request_a_govuk_domain/request/constants.py
+++ b/request_a_govuk_domain/request/constants.py
@@ -1,0 +1,10 @@
+"""
+Constants to be used across modules
+"""
+
+# This map links our email types to email templates defined in GOV.UK Notify and identified by their Notify UUID
+NOTIFY_TEMPLATE_ID_MAP = {
+    "confirmation": "d749d1a5-366c-4c0b-8e96-488150a62205",
+    "approval": "01992f67-0e0b-41b9-9191-ea1e878d018a",
+    "rejection": "a4fb5899-40bf-40dd-aff9-e76791da486d",
+}

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -9,6 +9,7 @@ from django.views import View
 from django.views.generic import TemplateView, RedirectView
 from django.views.generic.edit import FormView
 
+from .constants import NOTIFY_TEMPLATE_ID_MAP
 from .db import save_data_in_database
 from .forms import (
     DomainConfirmationForm,
@@ -403,7 +404,9 @@ def send_confirmation_email(request) -> None:
     }
     send_email(
         email_address=registration_data["registrar_email"],
-        template_id="d749d1a5-366c-4c0b-8e96-488150a62205",  # Notify API template id of Confirmation email
+        template_id=NOTIFY_TEMPLATE_ID_MAP[
+            "confirmation"
+        ],  # Notify API template id of Confirmation email
         personalisation=personalisation,
     )
 


### PR DESCRIPTION
Sends Approval/Rejection mail and shows message to the backend user accordingly
Also refactored notify templates into one constants.py file