### PR TITLE
Always send the user back to previous page

### DIFF
--- a/cypress/e2e/base.cy.js
+++ b/cypress/e2e/base.cy.js
@@ -1,9 +1,13 @@
-//============= Page title check ==================
+//============= Page contents checks ==================
 
 Cypress.Commands.add('checkPageTitleIncludes', expectedTitle => {
   return cy.get('h1').should('include.text', expectedTitle)
 })
 
+
+Cypress.Commands.add('checkBackLinkGoesTo', url =>
+  cy.get('.govuk-back-link').invoke('attr', 'href').should('eq', url)
+)
 
 Cypress.Commands.add('confirmProblem', (errorMessage, nb_errors = 1) => {
   cy.get('#error-summary-title').should('exist')
@@ -138,6 +142,7 @@ Cypress.Commands.add('goToRegistrarDetails', () => {
   cy.start()
   cy.get('a.govuk-button--start').click()
   cy.checkPageTitleIncludes('Registrar details')
+  cy.checkBackLinkGoesTo('/')
 })
 
 
@@ -145,6 +150,7 @@ Cypress.Commands.add('goToRegistrantType', () => {
   cy.goToRegistrarDetails()
   cy.fillOutRegistrarDetails('WeRegister', 'Joe Bloggs', '01225672345', 'joe@example.org')
   cy.checkPageTitleIncludes('Who is this domain name for?')
+  cy.checkBackLinkGoesTo('/registrar-details/')
 })
 
 
@@ -152,6 +158,7 @@ Cypress.Commands.add('goToDomainPurpose', () => {
   cy.goToRegistrantType()
   cy.chooseRegistrantType(1) // Central-gov -> route 2
   cy.checkPageTitleIncludes('Why do you want a .gov.uk domain name?')
+  cy.checkBackLinkGoesTo('/registrant-type/')
 })
 
 
@@ -159,12 +166,14 @@ Cypress.Commands.add('goToExemption', () => {
   cy.goToDomainPurpose()
   cy.chooseDomainPurpose(1) // Website -> route 7
   cy.checkPageTitleIncludes('Does your registrant have an exemption from using the GOV.UK website?')
+  cy.checkBackLinkGoesTo('/domain-purpose/')
 })
 
 Cypress.Commands.add('goToWrittenPermission', () => {
   cy.goToRegistrantType()
   cy.chooseRegistrantType(3) // Fire service -> route 3
   cy.checkPageTitleIncludes('Does your registrant have proof of permission to apply for a .gov.uk domain name?')
+  cy.checkBackLinkGoesTo('/registrant-type/')
 })
 
 
@@ -172,6 +181,7 @@ Cypress.Commands.add('goToExemptionUpload', () => {
   cy.goToExemption()
   cy.selectYesOrNo('exemption', 'yes')
   cy.checkPageTitleIncludes('Upload evidence of the exemption')
+  cy.checkBackLinkGoesTo('/exemption/')
 })
 
 
@@ -179,6 +189,7 @@ Cypress.Commands.add('goToExemptionUploadConfirm', filename => {
   cy.goToExemptionUpload()
   cy.uploadDocument(filename)
   cy.checkPageTitleIncludes('Upload evidence of the exemption')
+  cy.checkBackLinkGoesTo('/exemption-upload/')
 })
 
 
@@ -186,6 +197,7 @@ Cypress.Commands.add('goToWrittenPermission', () => {
   cy.goToRegistrantType()
   cy.chooseRegistrantType(4) // Route 3
   cy.checkPageTitleIncludes('Does your registrant have proof of permission to apply for a .gov.uk domain name?')
+  cy.checkBackLinkGoesTo('/registrant-type/')
 })
 
 
@@ -193,6 +205,7 @@ Cypress.Commands.add('goToWrittenPermissionUpload', filename => {
   cy.goToWrittenPermission()
   cy.selectYesOrNo('written_permission', 'yes')
   cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+  cy.checkBackLinkGoesTo('/written-permission/')
 })
 
 
@@ -200,12 +213,15 @@ Cypress.Commands.add('goToWrittenPermissionUploadConfirm', filename => {
   cy.goToWrittenPermissionUpload()
   cy.uploadDocument(filename)
   cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+  cy.checkBackLinkGoesTo('/written-permission-upload/')
 })
 
 
 Cypress.Commands.add('goToDomainConfirmation', (via_route = 1) => {
   cy.goToDomainViaRoute(via_route)
   cy.enterDomainName('something-pc')
+  cy.checkPageTitleIncludes('Is something-pc.gov.uk the correct domain name?')
+  cy.checkBackLinkGoesTo('/domain/')
 })
 
 
@@ -214,6 +230,7 @@ Cypress.Commands.add('goToDomainViaRoute', route => {
     cy.goToWrittenPermissionUploadConfirm('permission.png')
     cy.confirmUpload('permission.png')
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')
+    cy.checkBackLinkGoesTo('/written-permission-upload-confirm/')
   } else if (route === 2) {
     cy.goToDomainPurpose()
     cy.chooseDomainPurpose(1) // Route 5
@@ -229,12 +246,15 @@ Cypress.Commands.add('goToDomainViaRoute', route => {
     cy.checkPageTitleIncludes('Upload evidence of permission')
     cy.confirmUpload('permission.png')
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')
+    cy.checkBackLinkGoesTo('/written-permission-upload-confirm/')
   } else if (route === 1) {
     cy.goToRegistrantType()
     cy.chooseRegistrantType(3) // Parish -> route 1
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')
+    cy.checkBackLinkGoesTo('/registrant-type/')
   }
 })
+
 
 Cypress.Commands.add('goToMinister', () => {
   cy.goToDomainViaRoute(2)
@@ -242,18 +262,23 @@ Cypress.Commands.add('goToMinister', () => {
   cy.checkPageTitleIncludes('Is foobar.gov.uk the correct domain name?')
   cy.selectYesOrNo('domain_confirmation', 'yes')
   cy.checkPageTitleIncludes('Has a central government minister requested the foobar.gov.uk domain name?')
+  cy.checkBackLinkGoesTo('/domain-confirmation/')
 })
+
 
 Cypress.Commands.add('goToMinisterUpload', filename => {
   cy.goToMinister()
   cy.selectYesOrNo('minister', 'yes')
   cy.checkPageTitleIncludes('Upload evidence of the minister\'s request')
+  cy.checkBackLinkGoesTo('/minister/')
 })
+
 
 Cypress.Commands.add('goToMinisterUploadConfirm', filename => {
   cy.goToMinisterUpload()
   cy.uploadDocument(filename)
   cy.checkPageTitleIncludes('Upload evidence of the minister\'s request')
+  cy.checkBackLinkGoesTo('/minister-upload/')
 })
 
 
@@ -261,6 +286,7 @@ Cypress.Commands.add('goToRegistrantDetails', () => {
   cy.goToDomainConfirmation()
   cy.selectYesOrNo('domain_confirmation', 'yes')
   cy.checkPageTitleIncludes('Registrant details')
+  cy.checkBackLinkGoesTo('/domain-confirmation/')
 })
 
 
@@ -268,6 +294,7 @@ Cypress.Commands.add('goToRegistryDetails', () => {
   cy.goToRegistrantDetails()
   cy.fillOutRegistrantDetails('Littleton PC', 'Robert Smith', '01225672345', 'rob@example.com')
   cy.checkPageTitleIncludes('Registrant details for publishing to the registry')
+  cy.checkBackLinkGoesTo('/registrant-details/')
 })
 
 

--- a/cypress/e2e/happy-path-route-1-12.cy.js
+++ b/cypress/e2e/happy-path-route-1-12.cy.js
@@ -6,28 +6,36 @@ describe('Happy path - route 1-12', () => {
     cy.fillOutRegistrarDetails('WeRegister', 'Joe Bloggs', '01225672345', 'simulate-delivered@notifications.service.gov.uk')
 
     cy.checkPageTitleIncludes('Who is this domain name for?')
+    cy.checkBackLinkGoesTo('/registrar-details/')
     cy.chooseRegistrantType(3) // Parish or community council -> route 1
 
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')
+    cy.checkBackLinkGoesTo('/registrant-type/')
     cy.enterDomainName('something-pc')
 
     cy.checkPageTitleIncludes('Is something-pc.gov.uk the correct domain name?')
+    cy.checkBackLinkGoesTo('/domain/')
     cy.selectYesOrNo('domain_confirmation', 'no')
 
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')
+    cy.checkBackLinkGoesTo('/registrant-type/')
     cy.enterDomainName('somethingelse-pc')
 
     cy.checkPageTitleIncludes('Is somethingelse-pc.gov.uk the correct domain name?')
+    cy.checkBackLinkGoesTo('/domain/')
     cy.selectYesOrNo('domain_confirmation', 'yes')
 
     cy.checkPageTitleIncludes('Registrant details')
+    cy.checkBackLinkGoesTo('/domain-confirmation/')
     cy.get('p').should('include.text', 'For example, for Parish Councils the registrant must be the Clerk.')
     cy.fillOutRegistrantDetails('HMRC', 'Rob Roberts', '01225672344', 'rob@example.org')
 
     cy.checkPageTitleIncludes('Registrant details for publishing to the registry')
+    cy.checkBackLinkGoesTo('/registrant-details/')
     cy.fillOutRegistryDetails('Clerk', 'clerk@example.org')
 
     cy.checkPageTitleIncludes('Check your answers')
+    cy.checkBackLinkGoesTo('/registry-details/')
 
     cy.summaryShouldHave(0, 'WeRegister')
     cy.summaryShouldHave(1, ['Joe Bloggs', '01225672345', 'simulate-delivered@notifications.service.gov.uk'])

--- a/cypress/e2e/happy-path-route-1.cy.js
+++ b/cypress/e2e/happy-path-route-1.cy.js
@@ -6,23 +6,29 @@ describe('Happy path - route 1', () => {
     cy.fillOutRegistrarDetails('WeRegister', 'Joe Bloggs', '01225672345', 'simulate-delivered@notifications.service.gov.uk')
 
     cy.checkPageTitleIncludes('Who is this domain name for?')
+    cy.checkBackLinkGoesTo('/registrar-details/')
     cy.chooseRegistrantType(3) // Parish or community council -> route 1
 
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')
+    cy.checkBackLinkGoesTo('/registrant-type/')
     cy.enterDomainName('something-pc')
 
     cy.checkPageTitleIncludes('Is something-pc.gov.uk the correct domain name?')
+    cy.checkBackLinkGoesTo('/domain/')
     cy.selectYesOrNo('domain_confirmation', 'yes')
 
     cy.checkPageTitleIncludes('Registrant details')
+    cy.checkBackLinkGoesTo('/domain-confirmation/')
     cy.get('p').should('include.text', 'For example, for Parish Councils the registrant must be the Clerk.')
 
     cy.fillOutRegistrantDetails('HMRC', 'Rob Roberts', '01225672344', 'rob@example.org')
 
     cy.checkPageTitleIncludes('Registrant details for publishing to the registry')
+    cy.checkBackLinkGoesTo('/registrant-details/')
     cy.fillOutRegistryDetails('Clerk', 'clerk@example.org')
 
     cy.checkPageTitleIncludes('Check your answers')
+    cy.checkBackLinkGoesTo('/registry-details/')
 
     cy.summaryShouldHave(0, 'WeRegister')
     cy.summaryShouldHave(1, ['Joe Bloggs', '01225672345', 'simulate-delivered@notifications.service.gov.uk'])

--- a/cypress/e2e/happy-path-route-2-5-8.cy.js
+++ b/cypress/e2e/happy-path-route-2-5-8.cy.js
@@ -6,38 +6,49 @@ describe('Happy path - route 2-5-8', () => {
     cy.fillOutRegistrarDetails('WeRegister', 'Joe Bloggs', '01225672345', 'simulate-delivered@notifications.service.gov.uk')
 
     cy.checkPageTitleIncludes('Who is this domain name for?')
+    cy.checkBackLinkGoesTo('/registrar-details/')
     cy.chooseRegistrantType(1) // Central government -> Route 2
 
     cy.checkPageTitleIncludes('Why do you want a .gov.uk domain name?')
+    cy.checkBackLinkGoesTo('/registrant-type/')
     cy.chooseDomainPurpose(2) // Email address only -> Route 5
 
     cy.checkPageTitleIncludes('Does your registrant have proof of permission to apply for a .gov.uk domain name?')
+    cy.checkBackLinkGoesTo('/domain-purpose/')
     cy.get('p').should('include.text', 'chief information officer')
     cy.selectYesOrNo('written_permission', 'yes')
 
     cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkBackLinkGoesTo('/written-permission/')
     cy.uploadDocument("permission.png")
 
     cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkBackLinkGoesTo('/written-permission-upload/')
     cy.confirmUpload('permission.png')
 
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')
+    cy.checkBackLinkGoesTo('/written-permission-upload-confirm/')
     cy.enterDomainName('something-pc')
 
     cy.checkPageTitleIncludes('Is something-pc.gov.uk the correct domain name?')
+    cy.checkBackLinkGoesTo('/domain/')
     cy.selectYesOrNo('domain_confirmation', 'yes')
 
     cy.checkPageTitleIncludes('Has a central government minister requested the something-pc.gov.uk domain name?')
+    cy.checkBackLinkGoesTo('/domain-confirmation/')
     cy.selectYesOrNo('minister', 'no')
 
     cy.checkPageTitleIncludes('Registrant details')
+    cy.checkBackLinkGoesTo('/minister/')
     cy.get('p').should('not.include.text', 'the registrant must be the Clerk.')
     cy.fillOutRegistrantDetails('HMRC', 'Rob Roberts', '01225672344', 'rob@example.org')
 
     cy.checkPageTitleIncludes('Registrant details for publishing to the registry')
+    cy.checkBackLinkGoesTo('/registrant-details/')
     cy.fillOutRegistryDetails('Clerk', 'clerk@example.org')
 
     cy.checkPageTitleIncludes('Check your answers')
+    cy.checkBackLinkGoesTo('/registry-details/')
     cy.summaryShouldHave(0, 'WeRegister')
     cy.summaryShouldHave(1, ['Joe Bloggs', '01225672345', 'simulate-delivered@notifications.service.gov.uk'])
     cy.summaryShouldHave(2, 'Central government')

--- a/cypress/e2e/happy-path-route-2-5.cy.js
+++ b/cypress/e2e/happy-path-route-2-5.cy.js
@@ -6,44 +6,57 @@ describe('Happy path - route 2-5', () => {
     cy.fillOutRegistrarDetails('WeRegister', 'Joe Bloggs', '01225672345', 'simulate-delivered@notifications.service.gov.uk')
 
     cy.checkPageTitleIncludes('Who is this domain name for?')
+    cy.checkBackLinkGoesTo('/registrar-details/')
     cy.chooseRegistrantType(1) // Central government -> Route 2
 
     cy.checkPageTitleIncludes('Why do you want a .gov.uk domain name?')
+    cy.checkBackLinkGoesTo('/registrant-type/')
     cy.chooseDomainPurpose(2) // Email address only -> Route 5
 
     cy.checkPageTitleIncludes('Does your registrant have proof of permission to apply for a .gov.uk domain name?')
+    cy.checkBackLinkGoesTo('/domain-purpose/')
     cy.get('p').should('include.text', 'chief information officer')
     cy.selectYesOrNo('written_permission', 'yes')
 
     cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkBackLinkGoesTo('/written-permission/')
     cy.uploadDocument('permission.png')
 
     cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkBackLinkGoesTo('/written-permission-upload/')
     cy.confirmUpload('permission.png')
 
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')
+    cy.checkBackLinkGoesTo('/written-permission-upload-confirm/')
     cy.enterDomainName('something-pc')
 
     cy.checkPageTitleIncludes('Is something-pc.gov.uk the correct domain name?')
+    cy.checkBackLinkGoesTo('/domain/')
     cy.selectYesOrNo('domain_confirmation', 'yes')
 
     cy.checkPageTitleIncludes('Has a central government minister requested the something-pc.gov.uk domain name?')
+    cy.checkBackLinkGoesTo('/domain-confirmation/')
     cy.selectYesOrNo('minister', 'yes')
 
     cy.checkPageTitleIncludes('Upload evidence of the minister\'s request')
+    cy.checkBackLinkGoesTo('/minister/')
     cy.uploadDocument('minister.png')
 
     cy.checkPageTitleIncludes('Upload evidence of the minister\'s request')
+    cy.checkBackLinkGoesTo('/minister-upload/')
     cy.confirmUpload('minister.png')
 
     cy.checkPageTitleIncludes('Registrant details')
+    cy.checkBackLinkGoesTo('/minister-upload-confirm/')
     cy.get('p').should('not.include.text', 'For example, for Parish Councils the registrant must be the Clerk.')
     cy.fillOutRegistrantDetails('HMRC', 'Rob Roberts', '01225672344', 'rob@example.org')
 
     cy.checkPageTitleIncludes('Registrant details for publishing to the registry')
+    cy.checkBackLinkGoesTo('/registrant-details/')
     cy.fillOutRegistryDetails('Clerk', 'clerk@example.org')
 
     cy.checkPageTitleIncludes('Check your answers')
+    cy.checkBackLinkGoesTo('/registry-details/')
 
     cy.summaryShouldHave(0, 'WeRegister')
     cy.summaryShouldHave(1, ['Joe Bloggs', '01225672345', 'simulate-delivered@notifications.service.gov.uk'])

--- a/request_a_govuk_domain/request/templates/domain.html
+++ b/request_a_govuk_domain/request/templates/domain.html
@@ -5,7 +5,11 @@
 {% block title %}Domain{% endblock %}
 
 {% block beforeContent %}
-  {% url 'written_permission_upload_confirm' as back_url %}
+  {% if route.primary == 1 %}
+    {% url "registrant_type" as back_url %}
+  {% else %}
+    {% url "written_permission_upload_confirm" as back_url %}
+  {% endif %}
   {% back_link back_url %}
 {% endblock %}
 

--- a/request_a_govuk_domain/request/templates/registrant_details.html
+++ b/request_a_govuk_domain/request/templates/registrant_details.html
@@ -4,7 +4,13 @@
 {% block title %}Registrant details{% endblock %}
 
 {% block beforeContent %}
-  {% url "domain_confirmation" as back_url %}
+  {% if route.primary == 1 or route.primary == 3 %}
+    {% url "domain_confirmation" as back_url %}
+  {% elif route.primary == 2 and route.secondary == 5 and route.tertiary == 8 %}
+    {% url "minister" as back_url %}
+  {% else %}
+    {% url "minister_upload_confirm" as back_url %}
+  {% endif %}
   {% back_link back_url %}
 {% endblock %}
 

--- a/request_a_govuk_domain/request/templates/written_permission.html
+++ b/request_a_govuk_domain/request/templates/written_permission.html
@@ -4,7 +4,13 @@
 {% block title %}Written Permission{% endblock %}
 
 {% block beforeContent %}
-  {% url "registrant-type" as back_url %}
+  {% if route.primary == 2 and route.secondary == 5 %}
+    {% url "domain_purpose" as back_url %}
+  {% elif route.primary == 2 and route.secondary == 7 %}
+      {% url "exemption_upload_confirm" as back_url %}
+  {% else %}
+    {% url "registrant_type" as back_url %}
+  {% endif %}
   {% back_link back_url %}
 {% endblock %}
 

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -147,6 +147,12 @@ class DomainView(FormView):
         initial["domain_name"] = session_data.get("domain_name", "")
         return initial
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        registration_data = self.request.session.get("registration_data", {})
+        context["route"] = route_number(registration_data)
+        return context
+
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs["change"] = getattr(self, "change")


### PR DESCRIPTION
Depending on the path chosen, when the user lands on a specific page the back link needs to point back to the previous page. Since that depends on said path, we need to calculate it when the page is rendered.