### PR TITLE
Fix pre-commit/build errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,5 @@ repos:
         -    django-phonenumber-field
         -    django-storages
         -    boto3
+        -    clamd
+        -    notifications-python-client

--- a/request_a_govuk_domain/settings.py
+++ b/request_a_govuk_domain/settings.py
@@ -241,5 +241,5 @@ CLAMD_TCP_SOCKET = 3310
 if not DEBUG:
     CSRF_COOKIE_SECURE = True
     CSRF_COOKIE_HTTPONLY = True
-    CSRF_TRUSTED_ORIGINS = [f"https://{os.environ['DOMAIN_NAME']}"]
+    CSRF_TRUSTED_ORIGINS = [f"https://{os.environ.get('DOMAIN_NAME', 'localhost')}"]
     SESSION_COOKIE_SECURE = True


### PR DESCRIPTION
At the moment any pre-commit/build fails due to the following errors:

1.

    CSRF_TRUSTED_ORIGINS = [f"https://{os.environ['DOMAIN_NAME']}"]
                                       ~~~~~~~~~~^^^^^^^^^^^^^^^
  File "<frozen os>", line 685, in __getitem__
KeyError: 'DOMAIN_NAME'

2.

ModuleNotFoundError: No module named 'clamd'

3.

ModuleNotFoundError: No module named 'notifications_python_client'

These changes are to fix those errors