### PR TITLE
Updated Approval and Rejection Template ids

### DIFF
--- a/request_a_govuk_domain/request/constants.py
+++ b/request_a_govuk_domain/request/constants.py
@@ -5,6 +5,6 @@ Constants to be used across modules
 # This map links our email types to email templates defined in GOV.UK Notify and identified by their Notify UUID
 NOTIFY_TEMPLATE_ID_MAP = {
     "confirmation": "d749d1a5-366c-4c0b-8e96-488150a62205",
-    "approval": "01992f67-0e0b-41b9-9191-ea1e878d018a",
-    "rejection": "a4fb5899-40bf-40dd-aff9-e76791da486d",
+    "approval": "556c308e-f485-4f8e-9141-289e7129928a",
+    "rejection": "7dd2a2cb-d6c9-4549-a995-28ebe5f12315",
 }


### PR DESCRIPTION
The original templates were deleted by mistake and then new ones have been created, so the template ids have been updated in this commit.