### PR TITLE
Don't display the back-to-answers button on Registry details

### DIFF
--- a/cypress/e2e/change-answers.cy.js
+++ b/cypress/e2e/change-answers.cy.js
@@ -102,5 +102,17 @@ describe('Changing answers at the end of the process', () => {
     cy.checkPageTitleIncludes('Why do you want a .gov.uk domain name?')
   })
 
+  it('doesn\'t show the back-to-answers button when changing registry details', () => {
+    cy.goToConfirmation(7)
+    cy.get("a[href='/registry-details']").eq(0).click()
+    cy.checkPageTitleIncludes('Registrant details for publishing to the registry')
+
+    // No going back to answers because it's the last page before the confirmation page
+    cy.get('#id_back_to_answers').should('not.exist')
+
+    cy.fillOutRegistryDetails('Clerk', 'jim@example.com')
+    cy.checkPageTitleIncludes('Check your answers')
+    cy.summaryShouldHave(10, ['Clerk', 'jim@example.com'])
+  })
 
 })

--- a/request_a_govuk_domain/request/forms.py
+++ b/request_a_govuk_domain/request/forms.py
@@ -247,7 +247,6 @@ class RegistryDetailsForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        self.change = kwargs.pop("change", None)
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.label_size = Size.SMALL
@@ -264,10 +263,6 @@ class RegistryDetailsForm(forms.Form):
             ),
             Button("submit", "Continue"),
         )
-        if self.change:
-            self.helper.layout.fields.append(
-                Button.secondary("back_to_answers", "Back to answers")
-            )
 
 
 class WrittenPermissionForm(forms.Form):

--- a/request_a_govuk_domain/request/templates/confirm.html
+++ b/request_a_govuk_domain/request/templates/confirm.html
@@ -207,7 +207,7 @@
             {{ registration_data.registrant_contact_email }}
           {% endgds_summary_list_row_value %}
           {% gds_summary_list_row_actions %}
-            {% gds_summary_list_row_actions_item_inline text="Change" href="/change-registry-details" %}
+            {% gds_summary_list_row_actions_item_inline text="Change" href="/registry-details" %}
           {% endgds_summary_list_row_actions %}
         {% endgds_summary_list_row %}
       {% endgds_summary_list %}

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -241,12 +241,6 @@ class RegistryDetailsView(FormView):
     template_name = "registry_details.html"
     form_class = RegistryDetailsForm
     success_url = reverse_lazy("confirm")
-    change = False
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs["change"] = getattr(self, "change")
-        return kwargs
 
     def get_initial(self):
         initial = super().get_initial()

--- a/request_a_govuk_domain/urls.py
+++ b/request_a_govuk_domain/urls.py
@@ -83,11 +83,6 @@ urlpatterns = [
         RegistryDetailsView.as_view(),
         name="registry_details",
     ),
-    path(
-        "change-registry-details",
-        RegistryDetailsView.as_view(change=True),
-        name="change_registry_details",
-    ),
     path("domain-purpose/", DomainPurposeView.as_view(), name="domain_purpose"),
     path(
         "domain-purpose-fail/",


### PR DESCRIPTION
Since Registry details is the last form in the journey, the Back To Answers button did the same as the "Continue" button. Therefore we decided to remove "Back To Answers".

So if a user completes the form but goes back to change the Registry information they will only see a "continue" button that will take them back to Check your answers.