### PR TITLE
Add support for tag based deployment

### DIFF
--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -13,13 +13,17 @@ phases:
       - echo Building the Docker image...
       - docker build -t $REPOSITORY_URI:latest .
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
+      - echo $FOUND_TAG_NAME
+      - \[ ! -z $FOUND_TAG_NAME \] && docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$FOUND_TAG_NAME
   post_build:
     commands:
       - echo Pushing the Docker images...
-      - docker push $REPOSITORY_URI:latest
-      - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - docker image ls
+      - docker image push $REPOSITORY_URI --all-tags
       - export imageTag=$IMAGE_TAG
+      - export foundTagName=$FOUND_TAG_NAME
       - echo Build completed on `date`
 env:
   exported-variables:
     - imageTag
+    - foundTagName


### PR DESCRIPTION
`domains-container-iac` now set up to trigger on tags - each container app needs to implement a `FOUND_TAG_NAME` image tag - this is the tag found that triggered the pipeline, e.g. `test-0.0.1` 

This means that the image in ECR is tagged with the release tag from github