### PR TITLE
Add a govuk-styled 404 page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ up:
 up-devserver:
 	docker compose -f docker-compose.yml run --rm --service-ports --entrypoint "python manage.py runserver 0.0.0.0:8000" web
 
+up-devserver-nodebug:
+	docker compose -f docker-compose.yml run --rm --service-ports --entrypoint "python manage.py runserver 0.0.0.0:8000" --env DEBUG=False web
+
 down:
 	docker compose down
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Following are some of the make commands:
 
 `make up-devserver` - Run the application on docker using the Django development server
 
+`make up-devserver-nodebug` - Run the application on docker using the Django development server, but don't set Debug mode (to test error pages, for instance)
+
 `make shell` - Open a bash console within the running application container (you'll get an error if the service isn't running)
 
 `make down` - Stop the application on docker

--- a/cypress/e2e/error-pages.cy.js
+++ b/cypress/e2e/error-pages.cy.js
@@ -1,0 +1,8 @@
+import './base.cy'
+
+describe('Error pages (404/500 etc)', () => {
+  it('shows a 404 govuk-styled page', () => {
+    cy.visit("/doesnotexist-2432", { failOnStatusCode: false })
+    cy.get('p').should('include.text', 'If you entered a web address, check it is correct.')
+  })
+})

--- a/request_a_govuk_domain/request/templates/404.html
+++ b/request_a_govuk_domain/request/templates/404.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% load govuk_frontend_django %}
+
+{% block title %}Page not found{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">
+        Page not found
+      </h1>
+
+      <p class="govuk-body">
+        If you entered a web address, check it is correct.
+      </p>
+
+      <p class="govuk-body">
+        You can <a class="govuk-link" href="/">go back to the service's start page</a>.
+      </p>
+    </div>
+  </div>
+
+{% endblock %}

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -621,3 +621,7 @@ def service_failure_view(request):
     )
     request.session.pop("registration_data", None)
     return render(request, "500.html", status=500)
+
+
+def page_not_found_view(request, exception):
+    return render(request, "404.html", status=404)

--- a/request_a_govuk_domain/urls.py
+++ b/request_a_govuk_domain/urls.py
@@ -47,6 +47,7 @@ from .request.views import (
     DomainPurposeView,
     DomainPurposeFailView,
     service_failure_view,
+    page_not_found_view,
 )
 
 from .request.admin import DecisionConfirmationView
@@ -165,3 +166,4 @@ urlpatterns = [
 
 
 handler500 = service_failure_view
+handler404 = page_not_found_view

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-echo "Starting test server"
+echo "Starting test server with DEBUG set to False"
 export DEBUG=False
 poetry run ./manage.py runserver > /dev/null

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 echo "Starting test server"
+export DEBUG=False
 poetry run ./manage.py runserver > /dev/null


### PR DESCRIPTION
Normal Django way.

However for tests we need to disable DEBUG mode
We also add a new make target to develop locally with DEBUG=False, since otherwise error page tests will fail.
