### PR TITLE
Check that the key exists in the session dict

### DIFF
--- a/request_a_govuk_domain/request/utils.py
+++ b/request_a_govuk_domain/request/utils.py
@@ -142,19 +142,24 @@ def add_value_to_session(request, field_name: str, field_value) -> None:
     request.session["registration_data"] = registration_data
 
 
-def remove_from_session(session, field_names: list[str]) -> dict:
+def remove_from_session(session: dict, field_names: list[str]) -> dict:
     """
     Remove fields from a session, for instance when an uploaded
     file is removed
     """
-    for field_name in field_names:
-        if session["registration_data"].get(field_name) is not None:
-            if field_name.endswith("uploaded_filename"):
-                # remove the file associated
-                select_storage().delete(session["registration_data"].get(field_name))
-            del session["registration_data"][field_name]
+    if session and session.get("registration_data"):
+        for field_name in field_names:
+            if session["registration_data"].get(field_name) is not None:
+                if field_name.endswith("uploaded_filename"):
+                    # remove the file associated
+                    select_storage().delete(
+                        session["registration_data"].get(field_name)
+                    )
+                del session["registration_data"][field_name]
 
-    return session["registration_data"]
+        return session["registration_data"]
+    else:
+        return {}
 
 
 def get_env_variable(key: str, default=None) -> str:

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -562,7 +562,7 @@ class DomainPurposeView(FormView):
         # we need to remove downstream session fields in case we're
         # coming back from a check-your-answers page and selecting a new registrant
         # type that leads to a different route
-        remove_from_session(
+        session_data = remove_from_session(
             self.request.session,
             [
                 "domain_name",
@@ -591,7 +591,6 @@ class DomainPurposeView(FormView):
 
         # Pass the existing form answer if it is set in the session data
         initial = super().get_initial()
-        session_data = self.request.session["registration_data"]
         initial["domain_purpose"] = session_data.get("domain_purpose", "")
         return initial
 


### PR DESCRIPTION
In some cases of visiting a URL the session has no registration_data, for instance if the user enters a URL manually. Although this should be caught upstream and return a 403, it's still better to check here if the key exist, in order to avoid an unnecessary exception in the logs.