### PR TITLE
Add hashes for frontend inline scripts

### DIFF
--- a/request_a_govuk_domain/settings.py
+++ b/request_a_govuk_domain/settings.py
@@ -250,8 +250,8 @@ if not DEBUG:
 # Content Security Policy: only allow images, stylesheets and scripts from the
 # same origin as the HTML
 CSP_IMG_SRC = "'self'"
-CSP_STYLE_SRC = "'self' 'unsafe-inline'"
-CSP_SCRIPT_SRC = "'self' 'unsafe-inline'"
+CSP_STYLE_SRC = "'self'"
+CSP_SCRIPT_SRC = "'self' 'sha256-Gl/oWhJuv5Q73KslDBQ6Lf8TnR2wF1dznPZHMCb6P64=' 'sha256-mWnAScliK6FEboYjWY+46J2JHS2Rc/1osNHmEf8xhEg='"  # pragma: allowlist secret'
 CSP_FORM_ACTION = "'self'"
 CSP_FRAME_ANCESTORS = "'self'"
 


### PR DESCRIPTION
To avoid the CSP tripping when the pages are loaded