### PR TITLE
Open files in a new tab

### DIFF
--- a/request_a_govuk_domain/request/admin/model_admins.py
+++ b/request_a_govuk_domain/request/admin/model_admins.py
@@ -1,7 +1,9 @@
 from zoneinfo import ZoneInfo
 
+import django.db.models.fields.files
 import markdown
 from django.contrib import admin, messages
+from django.contrib.admin.widgets import AdminFileWidget
 from django.contrib.auth.admin import GroupAdmin, UserAdmin
 from django.http import HttpResponseRedirect, FileResponse
 from django.template.loader import render_to_string
@@ -339,6 +341,14 @@ class ReviewAdmin(admin.ModelAdmin):
         obj.application.save()
 
 
+class CustomAdminFileWidget(AdminFileWidget):
+    """
+    Extend the default template to open the links on a new tab
+    """
+
+    template_name = "admin/clearable_file_input.html"
+
+
 class ApplicationAdmin(admin.ModelAdmin):
     model = Application
     list_display = [
@@ -352,6 +362,9 @@ class ApplicationAdmin(admin.ModelAdmin):
         "owner",
     ]
     list_filter = ["status", "registrar_org", "registrant_org"]
+    formfield_overrides = {
+        django.db.models.fields.files.FileField: {"widget": CustomAdminFileWidget},
+    }
 
     @admin.display(description="Time Submitted (UK time)")
     def time_submitted_local_time(self, obj):

--- a/request_a_govuk_domain/request/templates/admin/clearable_file_input.html
+++ b/request_a_govuk_domain/request/templates/admin/clearable_file_input.html
@@ -1,0 +1,6 @@
+{% if widget.is_initial %}<p class="file-upload">{{ widget.initial_text }}: <a target="_blank" href="{{ widget.value.url }}">{{ widget.value }} (opens in new tab)</a>{% if not widget.required %}
+<span class="clearable-file-input">
+<input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}"{% if widget.attrs.disabled %} disabled{% endif %}>
+<label for="{{ widget.checkbox_id }}">{{ widget.clear_checkbox_label }}</label></span>{% endif %}<br>
+{{ widget.input_text }}:{% endif %}
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>{% if widget.is_initial %}</p>{% endif %}


### PR DESCRIPTION
Override the default template to support opening the new links on a new tab for the admin screens.