### PR TITLE
Maxf/more accessibility fixes

### DIFF
--- a/cypress/e2e/base.cy.js
+++ b/cypress/e2e/base.cy.js
@@ -188,7 +188,7 @@ Cypress.Commands.add('goToExemptionUpload', () => {
 Cypress.Commands.add('goToExemptionUploadConfirm', filename => {
   cy.goToExemptionUpload()
   cy.uploadDocument(filename)
-  cy.checkPageTitleIncludes('Upload evidence of the exemption')
+  cy.checkPageTitleIncludes('Confirm uploaded evidence of the exemption')
   cy.checkBackLinkGoesTo('/exemption-upload/')
 })
 
@@ -212,7 +212,7 @@ Cypress.Commands.add('goToWrittenPermissionUpload', filename => {
 Cypress.Commands.add('goToWrittenPermissionUploadConfirm', filename => {
   cy.goToWrittenPermissionUpload()
   cy.uploadDocument(filename)
-  cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+  cy.checkPageTitleIncludes('Confirm uploaded evidence of permission to apply')
   cy.checkBackLinkGoesTo('/written-permission-upload/')
 })
 
@@ -243,7 +243,7 @@ Cypress.Commands.add('goToDomainViaRoute', route => {
     cy.selectYesOrNo('written_permission', 'yes')
     cy.checkPageTitleIncludes('Upload evidence of permission')
     cy.uploadDocument('permission.png')
-    cy.checkPageTitleIncludes('Upload evidence of permission')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of permission')
     cy.confirmUpload('permission.png')
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')
     cy.checkBackLinkGoesTo('/written-permission-upload-confirm/')
@@ -277,7 +277,7 @@ Cypress.Commands.add('goToMinisterUpload', filename => {
 Cypress.Commands.add('goToMinisterUploadConfirm', filename => {
   cy.goToMinisterUpload()
   cy.uploadDocument(filename)
-  cy.checkPageTitleIncludes('Upload evidence of the minister\'s request')
+  cy.checkPageTitleIncludes('Confirm uploaded evidence of the minister\'s request')
   cy.checkBackLinkGoesTo('/minister-upload/')
 })
 
@@ -312,7 +312,7 @@ Cypress.Commands.add('goToConfirmation', (route=1) => {
     cy.checkPageTitleIncludes('Upload evidence of permission to apply')
     cy.uploadDocument('permission.png')
 
-    cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of permission to apply')
     cy.confirmUpload('permission.png')
 
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')
@@ -340,7 +340,7 @@ Cypress.Commands.add('goToConfirmation', (route=1) => {
     cy.checkPageTitleIncludes('Upload evidence of permission to apply')
     cy.uploadDocument("permission.png")
 
-    cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of permission to apply')
     cy.confirmUpload('permission.png')
 
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')
@@ -355,7 +355,7 @@ Cypress.Commands.add('goToConfirmation', (route=1) => {
     cy.checkPageTitleIncludes('Upload evidence of the minister\'s request')
     cy.uploadDocument("minister.png")
 
-    cy.checkPageTitleIncludes('Upload evidence of the minister\'s request')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of the minister\'s request')
     cy.confirmUpload('minister.png')
 
     cy.checkPageTitleIncludes('Registrant details')
@@ -378,7 +378,7 @@ Cypress.Commands.add('goToConfirmation', (route=1) => {
     cy.checkBackLinkGoesTo('/written-permission/')
     cy.uploadDocument('permission.png')
 
-    cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of permission to apply')
     cy.checkBackLinkGoesTo('/written-permission-upload/')
     cy.confirmUpload('permission.png')
 
@@ -398,7 +398,7 @@ Cypress.Commands.add('goToConfirmation', (route=1) => {
     cy.checkBackLinkGoesTo('/minister/')
     cy.uploadDocument('minister.png')
 
-    cy.checkPageTitleIncludes('Upload evidence of the minister\'s request')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of the minister\'s request')
     cy.checkBackLinkGoesTo('/minister-upload/')
     cy.confirmUpload('minister.png')
 

--- a/cypress/e2e/change-answers.cy.js
+++ b/cypress/e2e/change-answers.cy.js
@@ -1,6 +1,61 @@
 import './base.cy'
 
 describe('Changing answers at the end of the process', () => {
+
+  it('lets you change registry details', () => {
+    cy.goToConfirmation(7)
+    cy.get("a[href='/registry-details']").eq(0).click()
+    cy.checkPageTitleIncludes('Registrant details for publishing to the registry')
+    cy.get('#id_registrant_role').should('have.value', 'Clerk')
+    cy.get('#id_registrant_contact_email').should('have.value', 'clerk@example.org')
+
+    // change a value
+    cy.get('#id_registrant_role').clear().type('IT Support')
+
+    // go back to answers
+    cy.get('#id_submit').click()
+    cy.checkPageTitleIncludes('Check your answers')
+    cy.summaryShouldHave(10, 'IT Support')
+  })
+
+
+  it('lets you change registrant details', () => {
+    cy.goToConfirmation(7)
+    cy.get("a[href='/change-registrant-details']").eq(0).click()
+    cy.checkPageTitleIncludes('Registrant details')
+    cy.get('#id_registrant_organisation').should('have.value', 'HMRC')
+    cy.get('#id_registrant_full_name').should('have.value', 'Rob Roberts')
+    cy.get('#id_registrant_phone').should('have.value', '01225672344')
+    cy.get('#id_registrant_email').should('have.value', 'rob@example.org')
+
+    // change a value
+    cy.get('#id_registrant_phone').clear().type('01225672345')
+
+    // go back to answers
+    cy.get('#id_back_to_answers').click()
+    cy.checkPageTitleIncludes('Check your answers')
+    cy.summaryShouldHave(9, '01225672345')
+  })
+
+
+  it('lets you change registrar details', () => {
+    cy.goToConfirmation(7)
+    cy.get("a[href='/change-registrar-details']").eq(0).click()
+    cy.checkPageTitleIncludes('Registrar details')
+    cy.get('#id_registrar_name').should('have.value', 'Joe Bloggs')
+    cy.get('#id_registrar_phone').should('have.value', '01225672345')
+    cy.get('#id_registrar_email').should('have.value', 'joe@example.org')
+
+    // change a value
+    cy.get('#id_registrar_phone').clear().type('01225672345')
+
+    // go back to answers
+    cy.get('#id_back_to_answers').click()
+    cy.checkPageTitleIncludes('Check your answers')
+    cy.summaryShouldHave(1, '01225672345')
+  })
+
+
   it('lets you change your answer for the domain-purpose question', () => {
     cy.goToConfirmation(7)
     cy.get("a[href='/domain-purpose']").eq(0).click()
@@ -122,6 +177,10 @@ describe('Changing answers at the end of the process', () => {
     cy.get("a[href='/registry-details']").eq(0).click()
     cy.checkPageTitleIncludes('Registrant details for publishing to the registry')
 
+    // check previous answers are still there
+    cy.get('#id_registrant_role').should('have.value', 'Clerk')
+    cy.get('#id_registrant_contact_email').should('have.value', 'clerk@example.org')
+
     // No going back to answers because it's the last page before the confirmation page
     cy.get('#id_back_to_answers').should('not.exist')
 
@@ -133,8 +192,10 @@ describe('Changing answers at the end of the process', () => {
   it('doesn\'t ask for data again, even if you\'ve changed routes (route 5)', () => {
     cy.goToConfirmation(3)
     cy.get("a[href='/registrant-type']").click()
+    cy.get('input[type=radio]').eq(3).should('be.checked')
     cy.chooseRegistrantType(1) // change to route 2
     cy.checkPageTitleIncludes('Why do you want a .gov.uk domain name?')
+    cy.get('input[type=radio]').should('not.be.checked')
     cy.chooseDomainPurpose(2) // Email address only -> Route 5
 
     cy.checkPageTitleIncludes('Does your registrant have proof of permission to apply for a .gov.uk domain name?')

--- a/cypress/e2e/change-answers.cy.js
+++ b/cypress/e2e/change-answers.cy.js
@@ -142,7 +142,7 @@ describe('Changing answers at the end of the process', () => {
     cy.selectYesOrNo('written_permission', 'yes')
 
     // permission was already uploaded so it should still show
-    cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of permission to apply')
     cy.confirmUpload('permission.png')
 
     // same with domain name

--- a/cypress/e2e/errors-exemption.cy.js
+++ b/cypress/e2e/errors-exemption.cy.js
@@ -17,7 +17,7 @@ describe('Error messages for the Exemption form', () => {
     cy.selectYesOrNo('exemption', 'yes')
 
     // check we are on the next page
-  cy.checkPageTitleIncludes('Upload evidence of the exemption')
+    cy.checkPageTitleIncludes('Upload evidence of the exemption')
 
   })
 })

--- a/cypress/e2e/errors-uploads.cy.js
+++ b/cypress/e2e/errors-uploads.cy.js
@@ -21,7 +21,7 @@ describe('Errors when uploading files', () => {
 
     // do it right this time
     cy.uploadDocument('exemption.png')
-    cy.checkPageTitleIncludes('Upload evidence of the exemption')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of the exemption')
     cy.get('.govuk-tag').should('include.text', 'Uploaded')
   })
 
@@ -45,7 +45,7 @@ describe('Errors when uploading files', () => {
 
     // do it right this time
     cy.uploadDocument('permission.png')
-    cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of permission to apply')
     cy.get('.govuk-tag').should('include.text', 'Uploaded')
   })
 
@@ -69,7 +69,7 @@ describe('Errors when uploading files', () => {
 
     // do it right this time
     cy.uploadDocument('minister.png')
-    cy.checkPageTitleIncludes('Upload evidence of the minister\'s request')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of the minister\'s request')
     cy.get('.govuk-tag').should('include.text', 'Uploaded')
   })
 

--- a/cypress/e2e/errors-written-permission.cy.js
+++ b/cypress/e2e/errors-written-permission.cy.js
@@ -17,7 +17,7 @@ describe('Error messages for the Exemption form', () => {
     cy.selectYesOrNo('written_permission', 'yes')
 
     // check we are on the next page
-  cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkPageTitleIncludes('Upload evidence of permission to apply')
 
   })
 })

--- a/cypress/e2e/happy-path-route-2-5-8.cy.js
+++ b/cypress/e2e/happy-path-route-2-5-8.cy.js
@@ -22,7 +22,7 @@ describe('Happy path - route 2-5-8', () => {
     cy.checkBackLinkGoesTo('/written-permission/')
     cy.uploadDocument("permission.png")
 
-    cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of permission to apply')
     cy.checkBackLinkGoesTo('/written-permission-upload/')
     cy.confirmUpload('permission.png')
 

--- a/cypress/e2e/happy-path-route-2-5.cy.js
+++ b/cypress/e2e/happy-path-route-2-5.cy.js
@@ -22,7 +22,7 @@ describe('Happy path - route 2-5', () => {
     cy.checkBackLinkGoesTo('/written-permission/')
     cy.uploadDocument('permission.png')
 
-    cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of permission to apply')
     cy.checkBackLinkGoesTo('/written-permission-upload/')
     cy.confirmUpload('permission.png')
 
@@ -42,7 +42,7 @@ describe('Happy path - route 2-5', () => {
     cy.checkBackLinkGoesTo('/minister/')
     cy.uploadDocument('minister.png')
 
-    cy.checkPageTitleIncludes('Upload evidence of the minister\'s request')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of the minister\'s request')
     cy.checkBackLinkGoesTo('/minister-upload/')
     cy.confirmUpload('minister.png')
 

--- a/cypress/e2e/happy-path-route-2-7-8.cy.js
+++ b/cypress/e2e/happy-path-route-2-7-8.cy.js
@@ -17,7 +17,7 @@ describe('Happy path - route 2-7', () => {
     cy.checkPageTitleIncludes('Upload evidence of the exemption')
     cy.uploadDocument("exemption.png")
 
-    cy.checkPageTitleIncludes('Upload evidence of the exemption')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of the exemption')
     cy.confirmUpload('exemption.png')
 
     cy.checkPageTitleIncludes('Does your registrant have proof of permission to apply for a .gov.uk domain name?')
@@ -27,7 +27,7 @@ describe('Happy path - route 2-7', () => {
     cy.checkPageTitleIncludes('Upload evidence of permission to apply')
     cy.uploadDocument("permission.png")
 
-    cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of permission to apply')
     cy.confirmUpload('permission.png')
 
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')

--- a/cypress/e2e/happy-path-route-2-7-9.cy.js
+++ b/cypress/e2e/happy-path-route-2-7-9.cy.js
@@ -17,7 +17,7 @@ describe('Happy path - route 2-7-10', () => {
     cy.checkPageTitleIncludes('Upload evidence of the exemption')
     cy.uploadDocument("exemption.png")
 
-    cy.checkPageTitleIncludes('Upload evidence of the exemption')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of the exemption')
     cy.confirmUpload('exemption.png')
 
     cy.checkPageTitleIncludes('Does your registrant have proof of permission to apply for a .gov.uk domain name?')

--- a/cypress/e2e/happy-path-route-2-7.cy.js
+++ b/cypress/e2e/happy-path-route-2-7.cy.js
@@ -17,7 +17,7 @@ describe('Happy path - route 2-7', () => {
     cy.checkPageTitleIncludes('Upload evidence of the exemption')
     cy.uploadDocument("exemption.png")
 
-    cy.checkPageTitleIncludes('Upload evidence of the exemption')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of the exemption')
     cy.confirmUpload('exemption.png')
 
     cy.checkPageTitleIncludes('Does your registrant have proof of permission to apply for a .gov.uk domain name?')
@@ -27,7 +27,7 @@ describe('Happy path - route 2-7', () => {
     cy.checkPageTitleIncludes('Upload evidence of permission to apply')
     cy.uploadDocument("permission.png")
 
-    cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of permission to apply')
     cy.confirmUpload('permission.png')
 
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')
@@ -42,7 +42,7 @@ describe('Happy path - route 2-7', () => {
     cy.checkPageTitleIncludes('Upload evidence of the minister\'s request')
     cy.uploadDocument("minister.png")
 
-    cy.checkPageTitleIncludes('Upload evidence of the minister\'s request')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of the minister\'s request')
     cy.confirmUpload('minister.png')
 
     cy.checkPageTitleIncludes('Registrant details')

--- a/cypress/e2e/happy-path-route-3.cy.js
+++ b/cypress/e2e/happy-path-route-3.cy.js
@@ -15,7 +15,7 @@ describe('Happy path - route 3', () => {
     cy.checkPageTitleIncludes('Upload evidence of permission to apply')
     cy.uploadDocument('permission.png')
 
-    cy.checkPageTitleIncludes('Upload evidence of permission to apply')
+    cy.checkPageTitleIncludes('Confirm uploaded evidence of permission to apply')
     cy.confirmUpload('permission.png')
 
     cy.checkPageTitleIncludes('Choose a .gov.uk domain name')

--- a/request_a_govuk_domain/request/forms.py
+++ b/request_a_govuk_domain/request/forms.py
@@ -279,7 +279,7 @@ class WrittenPermissionForm(forms.Form):
     )
 
     written_permission = forms.ChoiceField(
-        label="",
+        label="Does your registrant have proof of permission to apply for a .gov.uk domain name?",
         choices=CHOICES,
         widget=forms.RadioSelect,
         error_messages={"required": "Please answer Yes or No"},

--- a/request_a_govuk_domain/request/templates/500.html
+++ b/request_a_govuk_domain/request/templates/500.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load govuk_frontend_django crispy_forms_gds %}
 
-{% block title %}Service fail{% endblock %}
+{% block title %}Problem with the service{% endblock %}
 
 {% block content %}
     <div class="govuk-width-container">

--- a/request_a_govuk_domain/request/templates/base.html
+++ b/request_a_govuk_domain/request/templates/base.html
@@ -7,7 +7,7 @@
   <meta name="theme-color" content="#0b0c0c">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <title>{% block title %}{% endblock %}</title>
+  <title>{% block title %}{% endblock %} - Get approval to use a .gov.uk domain name - GOV.UK</title>
 
 
   <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{% static "images/favicon.ico" %}" type="image/x-icon">

--- a/request_a_govuk_domain/request/templates/domain.html
+++ b/request_a_govuk_domain/request/templates/domain.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags crispy_forms_gds %}
 {% load govuk_frontend_django %}
 
-{% block title %}Domain{% endblock %}
+{% block title %}Choose a .gov.uk domain name{% endblock %}
 
 {% block beforeContent %}
   {% if route.primary == 1 %}

--- a/request_a_govuk_domain/request/templates/domain_confirmation.html
+++ b/request_a_govuk_domain/request/templates/domain_confirmation.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags crispy_forms_gds %}
 
-{% block title %}Domain confirmation{% endblock %}
+{% block title %}Confirm the domain name{% endblock %}
 
 {% block beforeContent %}
   {% url "domain" as back_url %}

--- a/request_a_govuk_domain/request/templates/domain_purpose.html
+++ b/request_a_govuk_domain/request/templates/domain_purpose.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags crispy_forms_gds %}
 
-{% block title %}Domain purpose{% endblock %}
+{% block title %}Why do you want a .gov.uk domain name?{% endblock %}
 
 {% block beforeContent %}
   {% url "registrant_type" as back_url %}

--- a/request_a_govuk_domain/request/templates/domain_purpose_fail.html
+++ b/request_a_govuk_domain/request/templates/domain_purpose_fail.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags crispy_forms_gds %}
 {% load govuk_frontend_django %}
 
-{% block title %}Domain purpose fail{% endblock %}
+{% block title %}Your registrant does not need a new third-level.gov.uk domain name{% endblock %}
 
 {% block beforeContent %}
   {% url 'domain_purpose' as back_url %}

--- a/request_a_govuk_domain/request/templates/exemption.html
+++ b/request_a_govuk_domain/request/templates/exemption.html
@@ -4,6 +4,35 @@
 
 {% block title %}Does your registrant have an exemption?{% endblock %}
 
+{% block extra_stylesheets %}
+  <style>
+   /*
+      Hide legend for visual modalities as it repeats the title
+      based on the GOV.UK Design System's govuk-visually-hidden
+      CSS class
+    */
+   legend::before {
+     content: "\00a0";
+   }
+   legend::after {
+     content: "\00a0";
+   }
+   .govuk-fieldset__legend.govuk-fieldset__legend--s {
+     position: absolute;
+     width: 1px;
+     height: 1px;
+     margin: 0;
+     padding: 0;
+     overflow: hidden;
+     clip: rect(0 0 0 0);
+     clip-path: inset(50%);
+     border: 0;
+     white-space: nowrap;
+     user-select: none;
+   }
+  </style>
+{% endblock %}
+
 {% block beforeContent %}
   {% url "domain_purpose" as back_url %}
   {% back_link back_url %}

--- a/request_a_govuk_domain/request/templates/exemption.html
+++ b/request_a_govuk_domain/request/templates/exemption.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags crispy_forms_gds %}
 {% load govuk_frontend_django %}
 
-{% block title %}Exemption{% endblock %}
+{% block title %}Does your registrant have an exemption?{% endblock %}
 
 {% block beforeContent %}
   {% url "domain_purpose" as back_url %}

--- a/request_a_govuk_domain/request/templates/exemption_fail.html
+++ b/request_a_govuk_domain/request/templates/exemption_fail.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags crispy_forms_gds %}
 {% load govuk_frontend_django %}
 
-{% block title %}Exemption fail{% endblock %}
+{% block title %}Your registrant cannot get approval{% endblock %}
 
 {% block beforeContent %}
   {% url 'exemption' as back_url %}

--- a/request_a_govuk_domain/request/templates/exemption_upload.html
+++ b/request_a_govuk_domain/request/templates/exemption_upload.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags crispy_forms_gds %}
 {% load govuk_frontend_django %}
 
-{% block title %}Exemption upload{% endblock %}
+{% block title %}Upload evidence of the exemption{% endblock %}
 
 {% block beforeContent %}
   {% url "exemption" as back_url %}

--- a/request_a_govuk_domain/request/templates/exemption_upload_confirm.html
+++ b/request_a_govuk_domain/request/templates/exemption_upload_confirm.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags crispy_forms_gds %}
 {% load govuk_frontend_django %}
 
-{% block title %}Exemption upload confirmation{% endblock %}
+{% block title %}Confirm uploaded evidence of the exemption{% endblock %}
 
 {% block beforeContent %}
   {% url "exemption_upload" as back_url %}
@@ -13,37 +13,37 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        Upload evidence of the exemption
-    </h2>
-    <div class="govuk-hint">
-      We support JPEG, PNG or PDF files. The maximum upload size is 10MB.
-    </div>
+        Confirm uploaded evidence of the exemption
+      </h1>
+      <div class="govuk-hint">
+        We support JPEG, PNG or PDF files. The maximum upload size is 10MB.
+      </div>
 
-    <dl class="govuk-summary-list govuk-summary-list--long-key">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <a class="govuk-link" id="uploaded-filename" href="{{ registration_data.exemption_file_uploaded_url }}" target="_blank">{{ registration_data.exemption_file_original_filename }}</a>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <strong class="govuk-tag govuk-tag--green">
-            Uploaded
-          </strong>
-        </dd>
+      <dl class="govuk-summary-list govuk-summary-list--long-key">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <a class="govuk-link" id="uploaded-filename" href="{{ registration_data.exemption_file_uploaded_url }}" target="_blank">{{ registration_data.exemption_file_original_filename }}</a>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <strong class="govuk-tag govuk-tag--green">
+              Uploaded
+            </strong>
+          </dd>
         <dd class="govuk-summary-list__actions">
           <a class="govuk-link" id="remove-link" href="{% url "exemption_upload_remove" %}">
             Remove<span class="govuk-visually-hidden"> {{ registration_data.original_filename }}</span>
           </a>
         </dd>
-      </div>
-    </dl>
-    <a class="govuk-button" id="button-continue" href="{% url "written_permission" %}">
-      Continue
-    </a>
-    {% if registration_data.change %}
-      <a class="govuk-button govuk-button--secondary" id="id_back_to_answers" href="{% url "confirm" %}">
-        Back to answers
+        </div>
+      </dl>
+      <a class="govuk-button" id="button-continue" href="{% url "written_permission" %}">
+        Continue
       </a>
-    {% endif %}
+      {% if registration_data.change %}
+        <a class="govuk-button govuk-button--secondary" id="id_back_to_answers" href="{% url "confirm" %}">
+          Back to answers
+        </a>
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/request_a_govuk_domain/request/templates/minister.html
+++ b/request_a_govuk_domain/request/templates/minister.html
@@ -3,6 +3,35 @@
 
 {% block title %}Has a central government minister requested the domain name?{% endblock %}
 
+{% block extra_stylesheets %}
+  <style>
+   /*
+      Hide legend for visual modalities as it repeats the title
+      based on the GOV.UK Design System's govuk-visually-hidden
+      CSS class
+    */
+   legend::before {
+     content: "\00a0";
+   }
+   legend::after {
+     content: "\00a0";
+   }
+   .govuk-fieldset__legend.govuk-fieldset__legend--s {
+     position: absolute;
+     width: 1px;
+     height: 1px;
+     margin: 0;
+     padding: 0;
+     overflow: hidden;
+     clip: rect(0 0 0 0);
+     clip-path: inset(50%);
+     border: 0;
+     white-space: nowrap;
+     user-select: none;
+   }
+  </style>
+{% endblock %}
+
 {% block beforeContent %}
   {% url "domain_confirmation" as back_url %}
   {% back_link back_url %}

--- a/request_a_govuk_domain/request/templates/minister.html
+++ b/request_a_govuk_domain/request/templates/minister.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags crispy_forms_gds %}
 
-{% block title %}Minister{% endblock %}
+{% block title %}Has a central government minister requested the domain name?{% endblock %}
 
 {% block beforeContent %}
   {% url "domain_confirmation" as back_url %}

--- a/request_a_govuk_domain/request/templates/minister_upload.html
+++ b/request_a_govuk_domain/request/templates/minister_upload.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags crispy_forms_gds %}
 {% load govuk_frontend_django %}
 
-{% block title %}Minister upload{% endblock %}
+{% block title %}Upload evidence of the minister's request{% endblock %}
 
 {% block beforeContent %}
   {% url "minister" as back_url %}

--- a/request_a_govuk_domain/request/templates/minister_upload_confirm.html
+++ b/request_a_govuk_domain/request/templates/minister_upload_confirm.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags crispy_forms_gds %}
 {% load govuk_frontend_django %}
 
-{% block title %}Minister upload confirm{% endblock %}
+{% block title %}Confirm uploaded evidence of the minister's request{% endblock %}
 
 {% block beforeContent %}
   {% url "minister_upload" as back_url %}
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        Upload evidence of the minister's request
+        Confirm uploaded evidence of the minister's request
       </h2>
       <div class="govuk-hint">
         We support JPEG, PNG or PDF files. The maximum upload size is 10MB.

--- a/request_a_govuk_domain/request/templates/registrant_type_fail.html
+++ b/request_a_govuk_domain/request/templates/registrant_type_fail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load govuk_frontend_django crispy_forms_gds %}
 
-{% block title %}Registrant organisation type fail{% endblock %}
+{% block title %}Your registrant is not eligible{% endblock %}
 
 {% block beforeContent %}
   {% url 'registrant_type' as back_url %}

--- a/request_a_govuk_domain/request/templates/registrar.html
+++ b/request_a_govuk_domain/request/templates/registrar.html
@@ -4,7 +4,7 @@
 {% load govuk_frontend_django %}
 
 
-{% block title %}Registrar organisation{% endblock %}
+{% block title %}Which .gov.uk Approved Registrar organisation are you from?{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/request_a_govuk_domain/request/templates/registry_details.html
+++ b/request_a_govuk_domain/request/templates/registry_details.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags crispy_forms_gds %}
 
-{% block title %}Registry details{% endblock %}
+{% block title %}Registrant details for publishing to the registry{% endblock %}
 
 {% block beforeContent %}
   {% url "registrant_details" as back_url %}

--- a/request_a_govuk_domain/request/templates/written_permission.html
+++ b/request_a_govuk_domain/request/templates/written_permission.html
@@ -3,6 +3,36 @@
 
 {% block title %}Does your registrant have proof of permission?{% endblock %}
 
+{% block extra_stylesheets %}
+  <style>
+   /*
+      Hide legend for visual modalities as it repeats the title
+      based on the GOV.UK Design System's govuk-visually-hidden
+      CSS class
+    */
+   legend::before {
+     content: "\00a0";
+   }
+   legend::after {
+     content: "\00a0";
+   }
+   .govuk-fieldset__legend.govuk-fieldset__legend--s {
+     position: absolute;
+     width: 1px;
+     height: 1px;
+     margin: 0;
+     padding: 0;
+     overflow: hidden;
+     clip: rect(0 0 0 0);
+     clip-path: inset(50%);
+     border: 0;
+     white-space: nowrap;
+     user-select: none;
+   }
+  </style>
+{% endblock %}
+
+
 {% block beforeContent %}
   {% if route.primary == 2 and route.secondary == 5 %}
     {% url "domain_purpose" as back_url %}

--- a/request_a_govuk_domain/request/templates/written_permission.html
+++ b/request_a_govuk_domain/request/templates/written_permission.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags crispy_forms_gds %}
 
-{% block title %}Written Permission{% endblock %}
+{% block title %}Does your registrant have proof of permission?{% endblock %}
 
 {% block beforeContent %}
   {% if route.primary == 2 and route.secondary == 5 %}

--- a/request_a_govuk_domain/request/templates/written_permission_fail.html
+++ b/request_a_govuk_domain/request/templates/written_permission_fail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load govuk_frontend_django crispy_forms_gds %}
 
-{% block title %}Written Permission fail{% endblock %}
+{% block title %}Your registrant does not have the evidence required{% endblock %}
 
 {% block beforeContent %}
   {% url 'written_permission' as back_url %}

--- a/request_a_govuk_domain/request/templates/written_permission_upload.html
+++ b/request_a_govuk_domain/request/templates/written_permission_upload.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags crispy_forms_gds %}
 {% load govuk_frontend_django %}
 
-{% block title %}Written permission upload{% endblock %}
+{% block title %}Upload evidence of permission to apply{% endblock %}
 
 {% block beforeContent %}
   {% url "written_permission" as back_url %}

--- a/request_a_govuk_domain/request/templates/written_permission_upload_confirm.html
+++ b/request_a_govuk_domain/request/templates/written_permission_upload_confirm.html
@@ -2,7 +2,7 @@
 {% load crispy_forms_tags crispy_forms_gds %}
 {% load govuk_frontend_django %}
 
-{% block title %}Written permission upload confirmation{% endblock %}
+{% block title %}Confirm uploaded evidence of permission to apply{% endblock %}
 
 {% block beforeContent %}
   {% url "written_permission_upload" as back_url %}
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        Upload evidence of permission to apply
+        Confirm uploaded evidence of permission to apply
     </h2>
     <div class="govuk-hint">
       We support JPEG, PNG or PDF files. The maximum upload size is 10MB.


### PR DESCRIPTION
Addressing all 3 "A" WCAG audit points:

1. Page titles are missing or don't describe the page in a useful way
2. Some forms are missing a label
3. Some information isn't remembered when the user comes back to a specific form (was corrected before but this PR adds tests to make sure)
