### PR TITLE
Fixed removal of minister session data

### DIFF
--- a/request_a_govuk_domain/request/db.py
+++ b/request_a_govuk_domain/request/db.py
@@ -82,7 +82,6 @@ def sanitise_registration_data(rd: dict) -> dict:
     if route.get("tertiary", 0) == 8:
         # If the final route taken doen't include minister support
         # then remove any possible minister support data previously specified.
-        rd.pop("minister", None)
         rd.pop("minister_file_uploaded_filename", None)
         rd.pop("minister_file_original_filename", None)
         rd.pop("minister_file_uploaded_url", None)


### PR DESCRIPTION
When user take a route where the answer for minister support is "No" e.g. when the route is central gov->Email->Minister-No, we are getting an error:
notifications_python_client.errors.HTTPError: 400 - [{'error': 'BadRequestError', 'message': 'Missing personalisation: minister'}]`

This is because the corresponding session data "minister" was being deleted. We should not remove the session data there, as it is later used during personalisation of corresponding email template, i.e. we should preserve the answer "no" provided by the user.

This change removes deletion of the minister session data in that scenario.