### PR TITLE
Reset the session when the users clicks the start button

### DIFF
--- a/cypress/e2e/regressions.cy.js
+++ b/cypress/e2e/regressions.cy.js
@@ -11,4 +11,24 @@ describe('Regression tests', () => {
 
     cy.checkPageTitleIncludes('Why do you want a .gov.uk domain name?')
   })
+
+  it('Resets the session if you click the start button again', () => {
+    cy.goToRegistrarDetails()
+    cy.fillOutRegistrarDetails('WeRegister', 'Joe Bloggs', '01225672345', 'simulate-delivered@notifications.service.gov.uk')
+    cy.checkPageTitleIncludes('Who is this domain name for?')
+
+    // Go back to the registrar details page
+    cy.get('a.govuk-back-link').click()
+
+    // check if the details are correctly remembered
+    cy.get('#id_registrar_name').should('have.value', 'Joe Bloggs')
+
+    // Now restart from the green button
+    cy.start()
+    cy.get('a.govuk-button--start').click()
+    cy.checkPageTitleIncludes('Registrar details')
+
+    // Values should not be remembered
+    cy.get('#id_registrar_name').should('have.value', '')
+  })
 })

--- a/request_a_govuk_domain/request/templates/start.html
+++ b/request_a_govuk_domain/request/templates/start.html
@@ -46,7 +46,7 @@
         <li>have the role and role-based email of your registrant to be published in the registry</li>
       </ul>
 
-      <a href="{% url "registrar_details" %}" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-module="govuk-button">
+      <a href="{% url "start_session" %}" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-module="govuk-button">
         Get approval
         <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
           <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -45,6 +45,17 @@ class StartView(TemplateView):
     template_name = "start.html"
 
 
+class StartSessionView(RedirectView):
+    pattern_name = "registrar_details"
+
+    def setup(self, request, *args, **kwargs):
+        # User has clicked the green button, so they're
+        # starting a new journey. Therefore delete the session data
+        # so that no previous answer is shown in the new journey.
+        request.session.pop("registration_data", None)
+        return super().setup(request, *args, **kwargs)
+
+
 class CookiesPageView(TemplateView):
     template_name = "cookies.html"
 

--- a/request_a_govuk_domain/urls.py
+++ b/request_a_govuk_domain/urls.py
@@ -23,6 +23,7 @@ from .request.views import (
     StartView,
     CookiesPageView,
     PrivacyPolicyPageView,
+    StartSessionView,
     RegistrarDetailsView,
     RegistrantTypeView,
     DomainView,
@@ -62,6 +63,7 @@ urlpatterns = [
     path("", StartView.as_view(), name="start"),
     path("cookies", CookiesPageView.as_view(), name="cookies_page"),
     path("privacy", PrivacyPolicyPageView.as_view(), name="privacy_policy"),
+    path("start-session/", StartSessionView.as_view(), name="start_session"),
     path(
         "registrar-details/", RegistrarDetailsView.as_view(), name="registrar_details"
     ),


### PR DESCRIPTION
We keep the session data throughout the user journey, whatever the path they take, until they submit their application. This is so that they never have to re-type the same thing twice even if they change routes.

However an exception to this should be when the user goes back to the start page and clicks the Start button.

In order to do that, the Start button now goes to a different url. The view for that URL resets the and then redirects to the first form (i.e. registrar details).