### PR TITLE
Convert the application submission to use forms

### DIFF
--- a/cypress/e2e/change-answers.cy.js
+++ b/cypress/e2e/change-answers.cy.js
@@ -15,7 +15,7 @@ describe('Changing answers at the end of the process', () => {
     cy.selectYesOrNo('domain_confirmation', 'yes')
     cy.fillOutRegistrantDetails('HMRC', 'Rob Roberts', '01225672344', 'rob@example.org')
     cy.fillOutRegistryDetails('Clerk', 'clerk@example.org')
-    cy.get('#button-continue').click()
+    cy.get('#id_submit').click()
     cy.checkApplicationIsOnBackend({
       domain: 'something-pc.gov.uk',
       registrar_org: 'WeRegister',
@@ -116,7 +116,7 @@ describe('Changing answers at the end of the process', () => {
     cy.checkPageTitleIncludes('Registrant details for publishing to the registry')
     cy.fillOutRegistryDetails('Clerk', 'clerk@example.org')
     cy.checkPageTitleIncludes('Check your answers')
-    cy.get('#button-continue').click()
+    cy.get('#id_submit').click()
 
     cy.checkPageTitleIncludes('Application submitted')
     cy.checkApplicationIsOnBackend({

--- a/cypress/e2e/errors-jump-around.cy.js
+++ b/cypress/e2e/errors-jump-around.cy.js
@@ -1,13 +1,22 @@
 import './base.cy'
 
 describe('Errors when user skips and jumps pages', () => {
-  it('Throws a 400 when user skips to success page', () => {
+  it('Throws a 404 when user skips to success page', () => {
 
     cy.goToRegistrantDetails()
 
     cy.request({ url: '/success', failOnStatusCode: false}).then(res => {
-      expect(res.status).to.eq(400)
-      expect(res.body).to.include('Invalid request')
+      expect(res.status).to.eq(404)
+    })
+  })
+
+  it('Throws a 200 when user skips to success page with param', () => {
+
+    cy.goToRegistrantDetails()
+
+    cy.request({ url: '/success/abc', failOnStatusCode: false}).then(res => {
+      expect(res.status).to.eq(200)
+      expect(res.body).to.include('abc')
     })
   })
 })

--- a/cypress/e2e/happy-path-route-1-12.cy.js
+++ b/cypress/e2e/happy-path-route-1-12.cy.js
@@ -50,7 +50,7 @@ describe('Happy path - route 1-12', () => {
     cy.summaryShouldHave(6, ['Clerk', 'clerk@example.org'])
     cy.summaryShouldNotHave(['Reason for request', 'Minister', 'Permission', 'Exemption'])
 
-    cy.get('#button-continue').click()
+    cy.get('#id_submit').click()
 
     cy.checkPageTitleIncludes('Application submitted')
     cy.checkApplicationIsOnBackend({

--- a/cypress/e2e/happy-path-route-1.cy.js
+++ b/cypress/e2e/happy-path-route-1.cy.js
@@ -44,7 +44,7 @@ describe('Happy path - route 1', () => {
     cy.summaryShouldHave(6, ['Clerk', 'clerk@example.org'])
     cy.summaryShouldNotHave(['Reason for request', 'Minister', 'Permission', 'Exemption'])
 
-    cy.get('#button-continue').click()
+    cy.get('#id_submit').click()
     cy.checkPageTitleIncludes('Application submitted')
 
     cy.checkPageTitleIncludes('Application submitted')

--- a/cypress/e2e/happy-path-route-2-5-8.cy.js
+++ b/cypress/e2e/happy-path-route-2-5-8.cy.js
@@ -64,7 +64,7 @@ describe('Happy path - route 2-5-8', () => {
     cy.summaryShouldHave(8, ['Rob Roberts', '01225672344', 'rob@example.org'])
     cy.summaryShouldHave(9, ['Clerk', 'clerk@example.org'])
 
-    cy.get('#button-continue').click()
+    cy.get('#id_submit').click()
 
     cy.checkPageTitleIncludes('Application submitted')
     cy.checkApplicationIsOnBackend({

--- a/cypress/e2e/happy-path-route-2-5.cy.js
+++ b/cypress/e2e/happy-path-route-2-5.cy.js
@@ -73,7 +73,7 @@ describe('Happy path - route 2-5', () => {
     cy.summaryShouldHave(8, ['Rob Roberts', '01225672344', 'rob@example.org'])
     cy.summaryShouldHave(9, ['Clerk', 'clerk@example.org'])
 
-    cy.get('#button-continue').click()
+    cy.get('#id_submit').click()
 
     cy.checkPageTitleIncludes('Application submitted')
     cy.checkApplicationIsOnBackend({

--- a/cypress/e2e/happy-path-route-2-7-8.cy.js
+++ b/cypress/e2e/happy-path-route-2-7-8.cy.js
@@ -64,7 +64,7 @@ describe('Happy path - route 2-7', () => {
     cy.summaryShouldHave(9, ['Rob Roberts', '01225672344', 'rob@example.org'])
     cy.summaryShouldHave(10, ['Clerk', 'clerk@example.org'])
 
-    cy.get('#button-continue').click()
+    cy.get('#id_submit').click()
 
     cy.checkPageTitleIncludes('Application submitted')
     cy.checkApplicationIsOnBackend({

--- a/cypress/e2e/happy-path-route-2-7.cy.js
+++ b/cypress/e2e/happy-path-route-2-7.cy.js
@@ -70,7 +70,7 @@ describe('Happy path - route 2-7', () => {
     cy.summaryShouldHave(9, ['Rob Roberts', '01225672344', 'rob@example.org'])
     cy.summaryShouldHave(10, ['Clerk', 'clerk@example.org'])
 
-    cy.get('#button-continue').click()
+    cy.get('#id_submit').click()
 
     cy.checkPageTitleIncludes('Application submitted')
     cy.checkApplicationIsOnBackend({

--- a/cypress/e2e/happy-path-route-3.cy.js
+++ b/cypress/e2e/happy-path-route-3.cy.js
@@ -46,7 +46,7 @@ describe('Happy path - route 3', () => {
     cy.summaryShouldHave(6, ['Rob Roberts', '01225672344', 'rob@example.org'])
     cy.summaryShouldHave(7, ['Clerk', 'clerk@example.org'])
 
-    cy.get('#button-continue').click()
+    cy.get('#id_submit').click()
 
     cy.checkPageTitleIncludes('Application submitted')
     cy.checkApplicationIsOnBackend({

--- a/request_a_govuk_domain/request/forms.py
+++ b/request_a_govuk_domain/request/forms.py
@@ -1,5 +1,6 @@
 import re
 
+from crispy_forms.layout import Hidden
 from crispy_forms_gds.choices import Choice
 from crispy_forms_gds.helper import FormHelper
 from crispy_forms_gds.layout import (
@@ -502,3 +503,18 @@ class DomainPurposeForm(forms.Form):
         self.fields["domain_purpose"].error_messages[
             "required"
         ] = "Select what you plan to use the .gov.uk domain name for"
+
+
+class ConfirmationForm(forms.Form):
+    reference = forms.HiddenInput()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            Hidden(name="reference", value=self.data.get("reference")),
+            Button(
+                "submit",
+                "Accept and send",
+            ),
+        )

--- a/request_a_govuk_domain/request/templates/confirm.html
+++ b/request_a_govuk_domain/request/templates/confirm.html
@@ -220,9 +220,7 @@
       <div class="govuk-body">
         By submitting this application you are confirming the details you are providing are correct to the best of your knowledge.
       </div>
-      <a class="govuk-button" id="button-continue" href="{% url "success" %}">
-        Accept and send
-      </a>
+      {% crispy form %}
     </div>
   </div>
 {% endblock %}

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -10,6 +10,7 @@ from django.urls import reverse_lazy
 from django.views import View
 from django.views.generic import TemplateView, RedirectView
 from django.views.generic.edit import FormView
+from django.db import IntegrityError
 
 from .constants import NOTIFY_TEMPLATE_ID_MAP
 from .db import save_data_in_database
@@ -367,9 +368,14 @@ class ConfirmView(TemplateView):
         :return:
         """
         reference_ = request.POST["reference"]
-        self.save_application_to_database_and_send_confirmation_email(
-            reference_, request
-        )
+        try:
+            self.save_application_to_database_and_send_confirmation_email(
+                reference_, request
+            )
+        except IntegrityError as e:
+            logger.warning(
+                f"Exception while saving data. {type(e).__name__} - {str(e)}"
+            )
         # We're finished, so clear the session data
         request.session.pop("registration_data", None)
         request.session.modified = True

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -25,6 +25,7 @@ from .forms import (
     RegistrantDetailsForm,
     RegistryDetailsForm,
     WrittenPermissionForm,
+    ConfirmationForm,
 )
 from .models.organisation import Registrar, RegistrantTypeChoices
 from .models.storage_util import select_storage
@@ -359,6 +360,61 @@ class MinisterUploadRemoveView(UploadRemoveView):
 class ConfirmView(TemplateView):
     template_name = "confirm.html"
 
+    def post(self, request):
+        """
+        Save the form and redirect to the success view.
+        :param request:
+        :return:
+        """
+        reference_ = request.POST["reference"]
+        self.save_application_to_database_and_send_confirmation_email(
+            reference_, request
+        )
+        # We're finished, so clear the session data
+        request.session.pop("registration_data", None)
+        request.session.modified = True
+        return redirect("success", reference=reference_)
+
+    @transaction.atomic  # This ensures that any failure during email send will not save data in db either
+    def save_application_to_database_and_send_confirmation_email(
+        self, reference: str, request: HttpRequest
+    ) -> None:
+        """
+        Saves data in the db and sends confirmation email
+
+        :param reference: Application reference
+        :param request: request object
+        """
+        logger.info(f"Saving form {request.session.session_key}")
+        save_data_in_database(reference, request)
+        self.send_confirmation_email(reference, request)
+
+    def send_confirmation_email(self, reference: str, request) -> None:
+        """
+        Method to send Confirmation email
+
+        It gets the required personalisation data from request and calls send_email to send the confirmation email
+
+        :param reference: Application reference
+        :param request: request object
+        """
+        registration_data = request.session.get("registration_data", {})
+
+        # Notify personalisation dictionary to be used in the notify templates
+        personalisation_dict = personalisation(reference, registration_data)
+
+        route_specific_email_template_name = route_specific_email_template(
+            "confirmation", registration_data
+        )
+
+        send_email(
+            email_address=registration_data["registrar_email"],
+            template_id=NOTIFY_TEMPLATE_ID_MAP[
+                route_specific_email_template_name
+            ],  # Notify API template id of route specific Confirmation email
+            personalisation=personalisation_dict,
+        )
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
@@ -381,76 +437,30 @@ class ConfirmView(TemplateView):
         ]
         # Pass the route number as what's on the page depends on it
         context["route"] = route_number(self.request.session.get("registration_data"))
-
+        form = ConfirmationForm({"reference": self.generate_reference()})
+        context["form"] = form
         return context
 
+    def generate_reference(self) -> str:
+        """
+        Generate application reference with the following format:
+        GOVUK + date in DDMMYYYY + random 4 letter alphabetical characters ( which don't have vowels and Y )
+        e.g. 'GOVUK12042024TRFT'
 
-def generate_reference() -> str:
-    """
-    Generate application reference with the following format:
-    GOVUK + date in DDMMYYYY + random 4 letter alphabetical characters ( which don't have vowels and Y )
-    e.g. 'GOVUK12042024TRFT'
+        Returns:
+            str: application reference.
+        """
 
-    Returns:
-        str: application reference.
-    """
+        random_letters = [
+            letter for letter in string.ascii_uppercase if letter not in "AEIOUY"
+        ]
+        random_string = "".join(random.choices(random_letters, k=4))
 
-    random_letters = [
-        letter for letter in string.ascii_uppercase if letter not in "AEIOUY"
-    ]
-    random_string = "".join(random.choices(random_letters, k=4))
-
-    return "GOVUK" + datetime.today().strftime("%d%m%Y") + random_string
-
-
-def send_confirmation_email(reference: str, request) -> None:
-    """
-    Method to send Confirmation email
-
-    It gets the required personalisation data from request and calls send_email to send the confirmation email
-
-    :param reference: Application reference
-    :param request: request object
-    """
-    registration_data = request.session.get("registration_data", {})
-
-    # Notify personalisation dictionary to be used in the notify templates
-    personalisation_dict = personalisation(reference, registration_data)
-
-    route_specific_email_template_name = route_specific_email_template(
-        "confirmation", registration_data
-    )
-
-    send_email(
-        email_address=registration_data["registrar_email"],
-        template_id=NOTIFY_TEMPLATE_ID_MAP[
-            route_specific_email_template_name
-        ],  # Notify API template id of route specific Confirmation email
-        personalisation=personalisation_dict,
-    )
-
-
-@transaction.atomic  # This ensures that any failure during email send will not save data in db either
-def save_application_to_database_and_send_confirmation_email(
-    reference: str, request: HttpRequest
-) -> None:
-    """
-    Saves data in the db and sends confirmation email
-
-    :param reference: Application reference
-    :param request: request object
-    """
-    logger.info(f"Saving form {request.session.session_key}")
-    save_data_in_database(reference, request)
-    send_confirmation_email(reference, request)
+        return "GOVUK" + datetime.today().strftime("%d%m%Y") + random_string
 
 
 class SuccessView(View):
-    def get(self, request):
-        reference = generate_reference()
-        save_application_to_database_and_send_confirmation_email(reference, request)
-        # We're finished, so clear the session data
-        request.session.pop("registration_data", None)
+    def get(self, request, reference: str):
         return render(request, "success.html", {"reference": reference})
 
 

--- a/request_a_govuk_domain/urls.py
+++ b/request_a_govuk_domain/urls.py
@@ -140,7 +140,7 @@ urlpatterns = [
         name="registrant_type_fail",
     ),
     path("confirm/", ConfirmView.as_view(), name="confirm"),
-    path("success/", SuccessView.as_view(), name="success"),
+    path("success/<str:reference>/", SuccessView.as_view(), name="success"),
     path(
         "exemption-upload-remove/",
         ExemptionUploadRemoveView.as_view(),

--- a/tests/test_application_submission.py
+++ b/tests/test_application_submission.py
@@ -1,0 +1,107 @@
+import concurrent
+import functools
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+from unittest.mock import Mock
+
+from django.db import connection
+from django.test import TransactionTestCase
+
+from request_a_govuk_domain.request.models import Registrar, Application
+from request_a_govuk_domain.request.views import ConfirmView
+
+
+def release_connection(wrapped_function):
+    # Decorator to release connection at the end.
+    # This should be usd to wrap the function that runs in a thread.
+    # There is a Django issue, that does not cose the connection if used within a thread pool
+    # https://stackoverflow.com/questions/44802617/database-is-being-accessed-by-other-users-error-when-using-threadpoolexecutor
+    # https://james.lin.net.nz/2016/04/22/make-sure-you-are-closing-the-db-connections-after-accessing-django-orm-in-your-threads/
+    #
+    @functools.wraps(wrapped_function)
+    def _release_connection(*args, **kwargs) -> Any:
+        try:
+            return wrapped_function(*args, **kwargs)
+        finally:
+            connection.close()
+
+    return _release_connection
+
+
+class ServiceFailureErrorHandlerTests(TransactionTestCase):
+    def setUp(self):
+        self.registrar = Registrar.objects.create(name="dummy registrar")
+        self.registration_data = {
+            "registrant_type": "parish_council",
+            "domain_name": "test.domain.gov.uk",
+            "registrar_name": "dummy registrar",
+            "registrar_email": "dummy_registrar_email@gov.uk",
+            "registrar_phone": "23456789",
+            "registrar_organisation": f"{self.registrar.name}-{self.registrar.id}",
+            "registrant_organisation": "dummy org",
+            "registrant_full_name": "dummy user",
+            "registrant_phone": "012345678",
+            "registrant_email": "dummy@test.gov.uk",
+            "registrant_role": "dummy",
+            "registrant_contact_email": "dummy@test.gov.uk",
+        }
+
+    def test_application_submit_saved(self):
+        """
+        If the token in the url does matches the one in the session,
+        then application saved.
+        :return:
+        """
+        s = self.client.session
+        s.update({"registration_data": self.registration_data})
+        s.save()
+        with self.assertLogs() as ctx_:
+            res = self.client.post("/confirm/", data={"reference": "GOVUK20062024QTLV"})
+            self.assertIn(
+                f"INFO:request_a_govuk_domain.request.views:Saving form {s.session_key}",
+                ctx_.output,
+            )
+            self.assertEqual(302, res.status_code)
+            self.assertEqual(1, Application.objects.count())
+
+    def test_application_submit_only_saved_once_on_concurrent_submits(self):
+        """
+        Make sure we only create one application in the database even if the user sends multiple
+        concurrent submits - multiple click on submit button
+        :return:
+        """
+
+        @release_connection
+        def make_request():
+            class SessionDict(dict):
+                def __init__(self, *k, **kwargs):
+                    self.__dict__ = self
+                    super().__init__(*k, **kwargs)
+                    self.session_key = "session-key"
+
+            mock_request = Mock()
+            mock_request.session = SessionDict(
+                {
+                    "registration_data": self.registration_data,
+                }
+            )
+            mock_request.POST = {"reference": "GOVUK20062024QTLV"}
+            return ConfirmView().post(mock_request)
+
+        num_threads = 5
+        with ThreadPoolExecutor() as executor:
+            features = [executor.submit(make_request) for i in range(num_threads)]
+            concurrent.futures.wait(features)
+        exception_count = 0
+        success_count = 0
+        for feature in features:
+            if feature._result:
+                success_count += 1
+            elif feature._exception:
+                exception_count += 1
+        # Only one will succeed
+        self.assertEqual(1, success_count)
+        # Remaining duplicate submissions will fail
+        self.assertEqual(4, exception_count)
+        # Only one application will be saved int the database
+        self.assertEqual(1, Application.objects.count())


### PR DESCRIPTION
Change the final application submission to use POST method and forms, so we can use csrf to prevent duplicate submissions.

Also using redirect to the final page to prevent the refresh causing multiple submissions.