### PR TITLE
email_address changed to registrar_email

### DIFF
--- a/request_a_govuk_domain/request/management/commands/check_email_failure.py
+++ b/request_a_govuk_domain/request/management/commands/check_email_failure.py
@@ -79,7 +79,7 @@ def send_failed_email(email_failure_notification: dict) -> None:
     personalisation = {
         "env": env,
         "reference": email_failure_notification["application_reference"],
-        "email_address": email_failure_notification["email_address"],
+        "registrar_email": email_failure_notification["email_address"],
         "status": email_failure_notification["status"],
     }
     notify_template_id = (


### PR DESCRIPTION
When failed email checker sends information on failed email to recipient, then for some reason Notify mixes up API call's email_address parameter with personalisation dictionary's "email_address" in Notify email log, although
the actual sent email is fine.

So functionally it works fine except for Notify's own email logs.

Hence making this change to distinguish between the two.