### PR TITLE
Throw 400 if no session data exists

### DIFF
--- a/cypress/e2e/errors-jump-around.cy.js
+++ b/cypress/e2e/errors-jump-around.cy.js
@@ -1,10 +1,9 @@
 import './base.cy'
 
 describe('Errors when user skips and jumps pages', () => {
+
   it('Throws a 404 when user skips to success page', () => {
-
     cy.goToRegistrantDetails()
-
     cy.request({ url: '/success', failOnStatusCode: false}).then(res => {
       expect(res.status).to.eq(404)
     })
@@ -19,4 +18,40 @@ describe('Errors when user skips and jumps pages', () => {
       expect(res.body).to.include('abc')
     })
   })
+
+  it('Throws a 400 when user goes back 6 pages after submitting', () => {
+    cy.goToConfirmation(1)
+    cy.get('.govuk-button#id_submit').click()
+    cy.checkPageTitleIncludes('Application submitted')
+    cy.go(-6)
+    cy.checkPageTitleIncludes('Invalid request')
+  })
+
+  it('Throws a 400 when user goes back 4 pages after submitting', () => {
+    cy.goToConfirmation(1)
+    cy.get('.govuk-button#id_submit').click()
+    cy.checkPageTitleIncludes('Application submitted')
+    cy.go(-4)
+    cy.checkPageTitleIncludes('Invalid request')
+  })
+
+  it('Throws a 400 when user goes back and forth after submitting', () => {
+    cy.goToConfirmation(1)
+    cy.get('.govuk-button#id_submit').click()
+    cy.checkPageTitleIncludes('Application submitted')
+    cy.go(-4)
+    cy.checkPageTitleIncludes('Invalid request')
+    cy.go(3)
+    cy.checkPageTitleIncludes('Invalid request')
+  })
+
+  it('Throws a 400 when user goes back after submitting', () => {
+    cy.goToConfirmation(1)
+    cy.get('.govuk-button#id_submit').click()
+    cy.checkPageTitleIncludes('Application submitted')
+    cy.go('back')
+    cy.checkPageTitleIncludes('Invalid request')
+  })
+
+
 })

--- a/request_a_govuk_domain/request/db.py
+++ b/request_a_govuk_domain/request/db.py
@@ -19,7 +19,7 @@ from request_a_govuk_domain.request.models import (
 )
 from .models.storage_util import select_storage
 
-from .utils import route_number, is_valid_session_data
+from .utils import route_number, is_valid_session_data, get_registration_data
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +98,7 @@ def save_data_in_database(reference, request):
     :param request: Request object
     """
 
-    session_data = request.session.get("registration_data", {})
+    session_data = get_registration_data(request)
     registration_data = sanitised_registration_data(
         session_data, request.session.session_key
     )

--- a/request_a_govuk_domain/request/utils.py
+++ b/request_a_govuk_domain/request/utils.py
@@ -4,7 +4,7 @@ import uuid
 
 import clamd
 from django.conf import settings
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, BadRequest
 from django.core.files.uploadedfile import UploadedFile
 from django.contrib.sessions.backends.db import SessionStore
 from notifications_python_client import NotificationsAPIClient
@@ -174,6 +174,20 @@ def is_valid_session_data(rd: dict) -> bool:
         ):
             return False
     return True
+
+
+def get_registration_data(request) -> dict:
+    """
+    Returns the registration dictionary or raise a 400 error (Bad Request) or it's missing,
+    since if it happens it probably means that the user's jumped to a random page without
+    being in an active session.
+    """
+    try:
+        return request.session["registration_data"]
+    except KeyError:
+        raise BadRequest(
+            "No session data found. User's probably gone to a random page without a session"
+        )
 
 
 def add_to_session(form, request, field_names: list[str]) -> dict:

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -38,6 +38,7 @@ from .utils import (
     send_email,
     route_specific_email_template,
     personalisation,
+    get_registration_data,
 )
 
 logger = logging.getLogger(__name__)
@@ -119,7 +120,7 @@ class RegistrantTypeView(FormView):
     form_class = RegistrantTypeForm
 
     def get_initial(self):
-        session_data = self.request.session["registration_data"]
+        session_data = get_registration_data(self.request)
         initial = super().get_initial()
         initial["registrant_type"] = session_data.get("registrant_type", "")
         return initial
@@ -146,7 +147,7 @@ class DomainView(FormView):
 
     def get_initial(self):
         initial = super().get_initial()
-        session_data = self.request.session["registration_data"]
+        session_data = get_registration_data(self.request)
         initial["domain_name"] = session_data.get("domain_name", "")
         return initial
 
@@ -185,7 +186,7 @@ class DomainConfirmationView(FormView):
 
     def get_initial(self):
         initial = super().get_initial()
-        session_data = self.request.session["registration_data"]
+        session_data = get_registration_data(self.request)
         initial["domain_confirmation"] = session_data.get("domain_confirmation", "")
         return initial
 
@@ -221,7 +222,7 @@ class RegistrantDetailsView(FormView):
 
     def get_initial(self):
         initial = super().get_initial()
-        session_data = self.request.session["registration_data"]
+        session_data = get_registration_data(self.request)
         initial["registrant_organisation"] = session_data.get(
             "registrant_organisation", ""
         )
@@ -253,7 +254,7 @@ class RegistryDetailsView(FormView):
 
     def get_initial(self):
         initial = super().get_initial()
-        session_data = self.request.session["registration_data"]
+        session_data = get_registration_data(self.request)
         initial["registrant_role"] = session_data.get("registrant_role", "")
         initial["registrant_contact_email"] = session_data.get(
             "registrant_contact_email", ""
@@ -286,7 +287,7 @@ class WrittenPermissionView(FormView):
 
     def get_initial(self):
         initial = super().get_initial()
-        session_data = self.request.session["registration_data"]
+        session_data = get_registration_data(self.request)
         initial["written_permission"] = session_data.get("written_permission", "")
         return initial
 
@@ -425,7 +426,7 @@ class ConfirmView(TemplateView):
         context = super().get_context_data(**kwargs)
 
         # Access session data and include it in the context
-        registration_data = self.request.session.get("registration_data", {})
+        registration_data = get_registration_data(self.request)
         context["registration_data"] = registration_data
 
         # Registrar organisation name: need to look up real name
@@ -476,7 +477,7 @@ class ExemptionView(FormView):
 
     def get_initial(self):
         initial = super().get_initial()
-        session_data = self.request.session["registration_data"]
+        session_data = get_registration_data(self.request)
         initial["exemption"] = session_data.get("exemption", "")
         return initial
 
@@ -502,7 +503,7 @@ class MinisterView(FormView):
 
     def get_initial(self):
         initial = super().get_initial()
-        session_data = self.request.session["registration_data"]
+        session_data = get_registration_data(self.request)
         initial["minister"] = session_data.get("minister", "")
         return initial
 
@@ -532,7 +533,7 @@ def download_file(request, file_type):
     :param file_type:  Type of file to be downloaded
     :return:
     """
-    registration_data = request.session["registration_data"]
+    registration_data = get_registration_data(request)
     storage = select_storage()
     file_name = registration_data[f"{file_type}_file_uploaded_filename"]
     if storage.exists(file_name):
@@ -616,7 +617,7 @@ class DomainPurposeView(FormView):
     form_class = DomainPurposeForm
 
     def get_initial(self):
-        session_data = self.request.session["registration_data"]
+        session_data = get_registration_data(self.request)
         initial = super().get_initial()
         initial["domain_purpose"] = session_data.get("domain_purpose", "")
         return initial


### PR DESCRIPTION
If the user is on a page which should have session data but doesn't then it means the user has ventured somewhere without a session.