### PR TITLE
Using celery broker transport options

### DIFF
--- a/request_a_govuk_domain/settings.py
+++ b/request_a_govuk_domain/settings.py
@@ -294,7 +294,7 @@ CELERY_TASK_DEFAULT_QUEUE = env.str("QUEUE_NAME", "celery")
 CELERY_BEAT_SCHEDULE_FILENAME = env.str(
     "CELERY_BEAT_SCHEDULE_FILENAME", default="celerybeat-schedule"
 )
-
+CELERY_BROKER_TRANSPORT_OPTIONS = env.json("CELERY_BROKER_TRANSPORT_OPTIONS", {})
 # The setting "CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True" is to get rid of the following deprecation warning
 # message, which shows up in the Cloudwatch Celery worker logs
 #


### PR DESCRIPTION
The celery transport options values for AWS SQS is provided as environment variable from IAC. This change is just to use those values.