### PR TITLE
Make falsy an invalid google analytics id in parameter store

### DIFF
--- a/request_a_govuk_domain/request/utils.py
+++ b/request_a_govuk_domain/request/utils.py
@@ -394,7 +394,10 @@ def variable_page_content(_request):
             "PHASE_CONTENT": "<div class='govuk-phase-banner__text'>This is a new service. Help us improve it, <a class='govuk-link' href='https://surveys.domains.gov.uk/s/VCVZSB/' target='_blank'>report a problem or give your feedback (opens in new tab)</a>.</div>",
         }
 
-    context["GOOGLE_ANALYTICS_ID"] = os.getenv("GOOGLE_ANALYTICS_ID")
+    google_analytics_id = os.getenv("GOOGLE_ANALYTICS_ID", "")
+    context["GOOGLE_ANALYTICS_ID"] = (
+        google_analytics_id if google_analytics_id[:2].upper() == "G-" else ""
+    )
 
     return context
 


### PR DESCRIPTION
Only set `context["GOOGLE_ANALYTICS_ID"]` if value in parameter store for the google analytics id (`/{env}/regapp/google-analytics-id`) starts with `G-`

This will mean that a non `G-` starting value is falsy

Can't reliably use regex