### PR TITLE
Allow 10 and 11-digit phone numbers

### DIFF
--- a/cypress/e2e/errors-registrar-details.cy.js
+++ b/cypress/e2e/errors-registrar-details.cy.js
@@ -22,6 +22,10 @@ describe('Error messages for registrar details', () => {
     cy.fillOutRegistrarDetails('WeRegister', 'Joe', '01 2', 'joe@example.com')
     cy.confirmProblem('Enter a telephone number, like 01632 960 001 or 07700 900 982')
 
+    // enter another bad phone number
+    cy.fillOutRegistrarDetails('WeRegister', 'Joe', '87746332234', 'joe@example.com')
+    cy.confirmProblem('Enter a telephone number, like 01632 960 001 or 07700 900 982')
+
     // enter a bad email address
     cy.fillOutRegistrarDetails('WeRegister', 'Joe', '01225123334', 'a@b.c')
     cy.confirmProblem('Enter an email address in the correct format, like name@example.co.uk')
@@ -31,6 +35,13 @@ describe('Error messages for registrar details', () => {
 
     // No error, we've moved on to the next page
     cy.checkPageTitleIncludes('Who is this domain name for?')
+  })
 
+  it('accepts 9-digit phone numbers (rare, but possible)', () => {
+    cy.goToRegistrarDetails()
+
+    cy.get('#id_registrar_organisation').clear().type('WeRegister')
+    cy.fillOutRegistrarDetails('WeRegister', 'Joe', '01234 56789', 'joe@example.com')
+    cy.checkPageTitleIncludes('Who is this domain name for?')
   })
 })

--- a/request_a_govuk_domain/request/validators.py
+++ b/request_a_govuk_domain/request/validators.py
@@ -9,7 +9,7 @@ class BaseValidator:
 
 
 class PhoneNumberValidator(BaseValidator):
-    phone_number_pattern = re.compile(r"^\s*\d(?:\s*\d){10}\s*$")
+    phone_number_pattern = re.compile(r"^\s*0(?:\s*\d){9,10}\s*$")
 
     def __call__(self, phone_number):
         if re.fullmatch(self.phone_number_pattern, phone_number) is None:


### PR DESCRIPTION
Most phone numbers in the UK are 11-digit long. However there are rare
numbers that are 10-digit long. This commit sets the number of allowed
digits to 10 or 11, and also mandates the first digits to be 0.
