### PR TITLE
Add an ID variable for Google Tag Manager

### DIFF
--- a/request_a_govuk_domain/request/templates/base.html
+++ b/request_a_govuk_domain/request/templates/base.html
@@ -3,7 +3,6 @@
 
   <head>
     {% if GOOGLE_ANALYTICS_ID %}
-      <!-- Google tag (gtag.js) --> <script nonce="{{request.csp_nonce}}" async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS_ID }}"></script> <script  nonce="{{request.csp_nonce}}"> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '{{ GOOGLE_ANALYTICS_ID }}'); </script>
       <!-- Google Tag Manager -->
       <script nonce="{{request.csp_nonce}}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
               new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/request_a_govuk_domain/request/utils.py
+++ b/request_a_govuk_domain/request/utils.py
@@ -394,9 +394,10 @@ def variable_page_content(_request):
             "PHASE_CONTENT": "<div class='govuk-phase-banner__text'>This is a new service. Help us improve it, <a class='govuk-link' href='https://surveys.domains.gov.uk/s/VCVZSB/' target='_blank'>report a problem or give your feedback (opens in new tab)</a>.</div>",
         }
 
+    # Google Tag Manager ID for inclusion in the HTML markup
     google_analytics_id = os.getenv("GOOGLE_ANALYTICS_ID", "")
     context["GOOGLE_ANALYTICS_ID"] = (
-        google_analytics_id if google_analytics_id[:2].upper() == "G-" else ""
+        google_analytics_id if google_analytics_id[:4].upper() == "GTM-" else ""
     )
 
     return context


### PR DESCRIPTION
The previous code used the same Google Analytics ID variable for both Google Analytics and Google Tag Manager. We need to differentiate them so we introduce another one for GTM.