### PR TITLE
Add a bogus google analytics tracking ID for tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ x-common-application-variables: &common-application-variables
   CELERY_BROKER_URL: redis://redis:6379/0
   NOMINET_ROMSID: test_romsid
   NOMINET_SECRET: test_secret # pragma: allowlist secret
+  GOOGLE_ANALYTICS_ID: GTM-TEST
 
 x-api-base: &api-base
   platform: linux/amd64


### PR DESCRIPTION
The celery tests that check the cookie banner need the google analytics snippet to be in the HTML in order to make sure it's not executed when rejecting cookies.

Whether the snippet is included in the HTML is decided by the existence of the GOOGLE_ANALYTICS_ID environment variable.

Therefore in order to run the tests when the app is running locally in docker , the container must have that variable set, with value which won't actually send data to our GA account.