### PR TITLE
Don't include the cookie banner if GA isn't set up

### DIFF
--- a/request_a_govuk_domain/request/static/cookies.js
+++ b/request_a_govuk_domain/request/static/cookies.js
@@ -8,33 +8,37 @@ const activateGtmScript = id => {
   script.parentNode.replaceChild(newScript, script);
 };
 
-if (!Cookies.get('cookies_preference_set')) {
-  document.querySelector('#cookie-banner').style.display = 'block';
-  const cookieButtons = document.querySelectorAll('#cookie-banner .govuk-button');
-  if (cookieButtons.length === 2) {
-    cookieButtons[0].addEventListener('click', () => {
-      Cookies.set('cookies_accepted', 'true', { secure: true, sameSite: 'strict' });
-      Cookies.set('cookies_preference_set', 'true', { secure: true, sameSite: 'strict' });
-      document.querySelector('#cookie-banner').style.display = 'none';
-      document.querySelector('#cookie-banner-done').style.display = 'block';
-      activateGtmScript('gtm-script');
-    });
-    cookieButtons[1].addEventListener('click', () => {
-      Cookies.set('cookies_accepted', 'false', { secure: true, sameSite: 'strict' });
-      Cookies.set('cookies_preference_set', 'true', { secure: true, sameSite: 'strict' });
-      document.querySelector('#cookie-banner').style.display = 'none';
-      document.querySelector('#cookie-banner-done').style.display = 'block';
-    });
-    const hideButton = document.querySelector('#cookie-banner-done .govuk-button');
-    if (hideButton) {
-      hideButton.addEventListener('click', () => {
-        document.querySelectorAll('.cookie-banner').forEach(banner => banner.style.display='none');
+
+const banner = document.querySelector('#cookie-banner');
+if (banner) {
+  if (!Cookies.get('cookies_preference_set')) {
+    banner.style.display = 'block';
+    const cookieButtons = document.querySelectorAll('#cookie-banner .govuk-button');
+    if (cookieButtons.length === 2) {
+      cookieButtons[0].addEventListener('click', () => {
+        Cookies.set('cookies_accepted', 'true', { secure: true, sameSite: 'strict' });
+        Cookies.set('cookies_preference_set', 'true', { secure: true, sameSite: 'strict' });
+        document.querySelector('#cookie-banner').style.display = 'none';
+        document.querySelector('#cookie-banner-done').style.display = 'block';
+        activateGtmScript('gtm-script');
       });
+      cookieButtons[1].addEventListener('click', () => {
+        Cookies.set('cookies_accepted', 'false', { secure: true, sameSite: 'strict' });
+        Cookies.set('cookies_preference_set', 'true', { secure: true, sameSite: 'strict' });
+        document.querySelector('#cookie-banner').style.display = 'none';
+        document.querySelector('#cookie-banner-done').style.display = 'block';
+      });
+      const hideButton = document.querySelector('#cookie-banner-done .govuk-button');
+      if (hideButton) {
+        hideButton.addEventListener('click', () => {
+          document.querySelectorAll('.cookie-banner').forEach(banner => banner.style.display='none');
+        });
+      }
     }
-  }
-} else {
-  if (Cookies.get('cookies_accepted') === 'true') {
-    activateGtmScript('gtm-script');
+  } else {
+    if (Cookies.get('cookies_accepted') === 'true') {
+      activateGtmScript('gtm-script');
+    }
   }
 }
 

--- a/request_a_govuk_domain/request/templates/base.html
+++ b/request_a_govuk_domain/request/templates/base.html
@@ -45,28 +45,30 @@
   {% endblock %}
 
   {% block header %}
-    <style>.cookie-banner { display: none }</style>
-    <div class="cookie-banner" id="cookie-banner">
-      {% gds_cookie_banner %}
-        {% gds_cookie_banner_message headingText="Cookies on Get approval to use a .gov.uk domain" %}
-          <p class="govuk-body">We use some essential cookies to make this website work.</p>
-          <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
-          <p class="govuk-body"><a class="govuk-link--no-visited-state" href="/cookies">View cookies</a></p>
+    {% if GOOGLE_ANALYTICS_ID %}
+      <style>.cookie-banner { display: none }</style>
+      <div class="cookie-banner" id="cookie-banner">
+        {% gds_cookie_banner %}
+          {% gds_cookie_banner_message headingText="Cookies on Get approval to use a .gov.uk domain" %}
+            <p class="govuk-body">We use some essential cookies to make this website work.</p>
+            <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+            <p class="govuk-body"><a class="govuk-link--no-visited-state" href="/cookies">View cookies</a></p>
 
-          {% gds_cookie_banner_message_action text="Accept analytics cookies" %}
-          {% gds_cookie_banner_message_action text="Reject analytics cookies" %}
-        {% endgds_cookie_banner_message %}
-      {% endgds_cookie_banner %}
-    </div>
+            {% gds_cookie_banner_message_action text="Accept analytics cookies" %}
+            {% gds_cookie_banner_message_action text="Reject analytics cookies" %}
+          {% endgds_cookie_banner_message %}
+        {% endgds_cookie_banner %}
+      </div>
 
-    <div class="cookie-banner" id="cookie-banner-done">
-      {% gds_cookie_banner %}
-        {% gds_cookie_banner_message %}
-          <p class="govuk-body">You have accepted additional cookies. You can <a href="/cookies">change your cookie settings</a> at any time.</p>
-          {% gds_cookie_banner_message_action text="Hide this message" %}
-        {% endgds_cookie_banner_message %}
-      {% endgds_cookie_banner %}
-    </div>
+      <div class="cookie-banner" id="cookie-banner-done">
+        {% gds_cookie_banner %}
+          {% gds_cookie_banner_message %}
+            <p class="govuk-body">You have accepted additional cookies. You can <a href="/cookies">change your cookie settings</a> at any time.</p>
+            {% gds_cookie_banner_message_action text="Hide this message" %}
+          {% endgds_cookie_banner_message %}
+        {% endgds_cookie_banner %}
+      </div>
+    {% endif %}
 
     <header class="govuk-header" role="banner" data-module="govuk-header">
       <div class="govuk-header__container govuk-width-container">
@@ -143,8 +145,11 @@
   {% block extra_script %}
   {% endblock %}
 
-  <script nonce="{{request.csp_nonce}}" src='{% static "js.cookie.min.js" %}'></script>
-  <script nonce="{{request.csp_nonce}}" src='{% static "cookies.js" %}'></script>
+  {% if GOOGLE_ANALYTICS_ID %}
+    <script nonce="{{request.csp_nonce}}" src='{% static "js.cookie.min.js" %}'></script>
+    <script nonce="{{request.csp_nonce}}" src='{% static "cookies.js" %}'></script>
+  {% endif %}
+
 </body>
 
 </html>

--- a/request_a_govuk_domain/request/templates/cookies.html
+++ b/request_a_govuk_domain/request/templates/cookies.html
@@ -34,37 +34,38 @@
         manage cookies (opens in a new tab)</a> .
       </p>
 
-      <style>#cookies-analytics { display: none }</style>
-      <div class="govuk-form-group govuk-!-margin-bottom-6" id="cookies-analytics">
-        <fieldset class="govuk-fieldset" aria-describedby="hint-0c454062">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-            <h2 class="govuk-fieldset__heading">Cookies that measure website use</h2>
-          </legend>
+      {% if GOOGLE_ANALYTICS_ID %}
+        <style>#cookies-analytics { display: none }</style>
+        <div class="govuk-form-group govuk-!-margin-bottom-6" id="cookies-analytics">
+          <fieldset class="govuk-fieldset" aria-describedby="hint-0c454062">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h2 class="govuk-fieldset__heading">Cookies that measure website use</h2>
+            </legend>
 
-          <div id="hint-0c454062" class="govuk-hint">
-            <p class="govuk-body govuk-hint">We use Google Analytics cookies to measure how you use GOV.UK and government digital services.</p>
-            <p class="govuk-body govuk-hint">These cookies collect information about:</p>
-            <ul class="govuk-list--bullet govuk-hint">
-              <li>how you got to these sites</li>
-              <li>the pages you visit and how long you spend on each page</li>
-              <li>what you click on while you're visiting these sites</li>
-            </ul>
-            <p class="govuk-body govuk-hint">We do not allow Google to use or share this data for their own purposes.</p>
-         </div>
-         <div class="govuk-radios">
-           <div class="govuk-radios__item">
-             <input type="radio" name="cookies-usage" id="use-cookies" value="on" class="govuk-radios__input">
-             <label for="use-cookies" class="govuk-label govuk-radios__label">Use cookies that measure my website use</label>
+            <div id="hint-0c454062" class="govuk-hint">
+              <p class="govuk-body govuk-hint">We use Google Analytics cookies to measure how you use GOV.UK and government digital services.</p>
+              <p class="govuk-body govuk-hint">These cookies collect information about:</p>
+              <ul class="govuk-list--bullet govuk-hint">
+                <li>how you got to these sites</li>
+                <li>the pages you visit and how long you spend on each page</li>
+                <li>what you click on while you're visiting these sites</li>
+              </ul>
+              <p class="govuk-body govuk-hint">We do not allow Google to use or share this data for their own purposes.</p>
            </div>
-           <div class="govuk-radios__item">
-             <input type="radio" name="cookies-usage" id="no-cookies" value="off" class="govuk-radios__input" checked="">
-             <label for="no-cookies" class="govuk-label govuk-radios__label">Do not use cookies that measure my website use</label>
+           <div class="govuk-radios">
+             <div class="govuk-radios__item">
+               <input type="radio" name="cookies-usage" id="use-cookies" value="on" class="govuk-radios__input">
+               <label for="use-cookies" class="govuk-label govuk-radios__label">Use cookies that measure my website use</label>
+             </div>
+             <div class="govuk-radios__item">
+               <input type="radio" name="cookies-usage" id="no-cookies" value="off" class="govuk-radios__input" checked="">
+               <label for="no-cookies" class="govuk-label govuk-radios__label">Do not use cookies that measure my website use</label>
+             </div>
            </div>
-         </div>
-        </fieldset>
-        <button id="save-cookies" class="govuk-!-margin-top-5 govuk-button" type="submit">Save changes</button>
-      </div>
-
+          </fieldset>
+          <button id="save-cookies" class="govuk-!-margin-top-5 govuk-button" type="submit">Save changes</button>
+        </div>
+      {% endif %}
       <h2 class="govuk-heading-m">
         Essential cookies
       </h2>


### PR DESCRIPTION
If the GOOGLE_ANALYTICS_ID environment variable doesn't have a valid value, we shouldn't even show the cookie banner or the form controls on the cookies page.