### PR TITLE
Reduce the session timeout

### DIFF
--- a/request_a_govuk_domain/settings.py
+++ b/request_a_govuk_domain/settings.py
@@ -257,6 +257,9 @@ if not DEBUG:
     CSRF_FAILURE_VIEW = "request_a_govuk_domain.request.views.csrf_failure_view"
     SESSION_COOKIE_SECURE = True
 
+# Set session (end-user or admin) to expire in 24 hours
+SESSION_COOKIE_AGE = 24 * 60 * 60
+
 # Content Security Policy: only allow images, stylesheets and scripts from the
 # same origin as the HTML
 CSP_IMG_SRC = "'self'"


### PR DESCRIPTION
The default session timeout is 2 weeks, which is too long for our usage. Reduce it to 24 hours