### PR TITLE
Avoiding the multiple clicks on Application Submission.

### DIFF
--- a/request_a_govuk_domain/request/db.py
+++ b/request_a_govuk_domain/request/db.py
@@ -98,6 +98,12 @@ def save_data_in_database(reference, request):
     :param request: Request object
     """
 
+    # get the application here and return status as False.
+    # since the application already is created in DB.
+    application = Application.objects.filter(reference=reference)
+    if application:
+        return False
+
     session_data = get_registration_data(request)
     registration_data = sanitised_registration_data(
         session_data, request.session.session_key
@@ -164,7 +170,7 @@ def save_data_in_database(reference, request):
                 "Saved application %d with reference %s", application.id, reference
             )
             Review.objects.create(application=application)
-        return application
+        return True
     except Exception as e:
         logger.error(
             f"""Exception while saving data. Exception: {type(e).__name__} - {str(e)} ,

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -384,15 +384,18 @@ class ConfirmView(TemplateView):
         :return:
         """
         reference_ = request.session.get(APPLICATION_REFERENCE)
-        self.save_application_to_database_and_send_confirmation_email(
+        status = self.save_application_to_database_and_send_confirmation_email(
             reference_, request
         )
-        return redirect("success")
+        if status:
+            return redirect("success")
+        else:
+            return HttpResponseNotFound()
 
     @transaction.atomic  # This ensures that any failure during email send will not save data in db either
     def save_application_to_database_and_send_confirmation_email(
         self, reference: str, request: HttpRequest
-    ) -> None:
+    ):
         """
         Saves data in the db and sends confirmation email
 
@@ -400,8 +403,9 @@ class ConfirmView(TemplateView):
         :param request: request object
         """
         logger.info(f"Saving form {request.session.session_key}")
-        save_data_in_database(reference, request)
+        status = save_data_in_database(reference, request)
         self.send_confirmation_email(reference, request)
+        return status
 
     def send_confirmation_email(self, reference: str, request) -> None:
         """

--- a/tests/test_admin_approval.py
+++ b/tests/test_admin_approval.py
@@ -46,7 +46,8 @@ class ModelAdminTestCase(AdminScreenTestMixin, TestCase):
         request.session = SessionDict({"registration_data": self.registration_data})
 
         # Simulate application creation through client screens
-        application = db.save_data_in_database("ABCDEFGHIJK", request)
+        db.save_data_in_database("ABCDEFGHIJK", request)
+        application = Application.objects.filter(reference="ABCDEFGHIJK")[0]
 
         # Application retrieval, check original condition
         response = self.admin_client.get(get_admin_change_view_url(application))
@@ -98,7 +99,8 @@ class ModelAdminTestCase(AdminScreenTestMixin, TestCase):
         # Make the application email unique so that we are sure when we compare the data later
         self.registration_data["registrar_email"] = "dummy_registrar_email-xx@gov.uk"
         # Simulate application creation through client screens
-        application_to_approve = db.save_data_in_database("ABCDEFGHIJG", request)
+        db.save_data_in_database("ABCDEFGHIJG", request)
+        application_to_approve = Application.objects.filter(reference="ABCDEFGHIJG")[0]
 
         # Now we review the last application created by the client
         review = Review.objects.filter(

--- a/tests/test_admin_history.py
+++ b/tests/test_admin_history.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 from django.test import TestCase
 
 from request_a_govuk_domain.request import db
-from request_a_govuk_domain.request.models import Review
+from request_a_govuk_domain.request.models import Review, Application
 from request_a_govuk_domain.request.templatetags.admin_tags import format_date
 from tests.util import (
     AdminScreenTestMixin,
@@ -27,7 +27,8 @@ class SimpleHistoryTest(AdminScreenTestMixin, TestCase):
         request.session = SessionDict({"registration_data": self.registration_data})
 
         # Simulate application creation through client screens
-        application = db.save_data_in_database("ABCDEFGHIJK", request)
+        db.save_data_in_database("ABCDEFGHIJK", request)
+        application = Application.objects.filter(reference="ABCDEFGHIJK")[0]
         sleep(1)
 
         # Simulate 1st review user interaction.

--- a/tests/test_application_submission.py
+++ b/tests/test_application_submission.py
@@ -2,7 +2,7 @@ import concurrent
 import functools
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from django.db import connection
 from django.test import TransactionTestCase
@@ -183,3 +183,31 @@ class ServiceFailureErrorHandlerTests(TransactionTestCase):
             # Try to save the application without any session data
             mock_request.POST = {}
             return ConfirmView().post(mock_request)
+
+    def test_application_success(self):
+        """
+        successfull response
+        :return:
+        """
+
+        with patch(
+            "request_a_govuk_domain.request.views.ConfirmView.save_application_to_database_and_send_confirmation_email"
+        ) as mock_save:
+            mock_save.return_value = True
+            res = self.client.post("/confirm/", data={})
+
+        self.assertEqual(302, res.status_code)
+
+    def test_application_failure(self):
+        """
+        failure response
+        :return:
+        """
+        with patch(
+            "request_a_govuk_domain.request.views.ConfirmView.save_application_to_database_and_send_confirmation_email"
+        ) as mock_save:
+            mock_save.return_value = False
+            # self.client.raise_request_exception = False
+            res = self.client.post("/confirm/", data={})
+
+        self.assertEqual(404, res.status_code)

--- a/tests/test_model_admins.py
+++ b/tests/test_model_admins.py
@@ -10,7 +10,7 @@ from parameterized import parameterized
 
 from request_a_govuk_domain.request import db
 from request_a_govuk_domain.request.admin.model_admins import convert_to_local_time
-from request_a_govuk_domain.request.models import Registrar
+from request_a_govuk_domain.request.models import Registrar, Application
 
 
 class ModelAdminTestCase(TestCase):
@@ -70,7 +70,8 @@ class ModelAdminTestCase(TestCase):
     def test_file_is_uploaded_from_admin_screen(self, file_name, expected_name):
         request = Mock()
         request.session = SessionDict({"registration_data": self.registration_data})
-        app = db.save_data_in_database("ABCDEFGHIJK", request)
+        db.save_data_in_database("ABCDEFGHIJK", request)
+        app = Application.objects.filter(reference="ABCDEFGHIJK")[0]
         c = Client()
         c.login(username="superuser", password="secret")  # pragma: allowlist secret
 

--- a/tests/test_model_history.py
+++ b/tests/test_model_history.py
@@ -8,6 +8,7 @@ from request_a_govuk_domain.request.models import (
     ApplicationStatus,
 )
 from tests.util import get_admin_change_view_url, SessionDict, AdminScreenTestMixin
+from request_a_govuk_domain.request.models import Application
 
 
 class CheckHistoryTestCase(AdminScreenTestMixin, TestCase):
@@ -21,7 +22,8 @@ class CheckHistoryTestCase(AdminScreenTestMixin, TestCase):
         request.session = SessionDict({"registration_data": self.registration_data})
 
         # Simulate application creation through client screens
-        application = db.save_data_in_database("ABCDEFGHIJK", request)
+        db.save_data_in_database("ABCDEFGHIJK", request)
+        application = Application.objects.filter(reference="ABCDEFGHIJK")[0]
 
         # see the records in history table
         history = application.history.all()  # type: ignore
@@ -46,7 +48,8 @@ class CheckHistoryTestCase(AdminScreenTestMixin, TestCase):
         request.session = SessionDict({"registration_data": self.registration_data})
 
         # Simulate application creation through client screens
-        application = db.save_data_in_database("ABCDEFGHIJL", request)
+        db.save_data_in_database("ABCDEFGHIJL", request)
+        application = Application.objects.filter(reference="ABCDEFGHIJL")[0]
 
         # Now we review the last application created by the client
         review = Review.objects.filter(


### PR DESCRIPTION
1. checking if the application already exists and returning a bool.
2. If multiple clicks detected, throw a HttpResponseNotFound.