### PR TITLE
Add CSP rules and a way to check breaches

### DIFF
--- a/.github/workflows/start-server.sh
+++ b/.github/workflows/start-server.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 DEBUG=False
+export TEST_CSP=yes
 echo "Starting test server with DEBUG set to ${DEBUG}"
 GOOGLE_ANALYTICS_ID=GTM-TEST poetry run ./manage.py runserver 0.0.0.0:8010

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -4,6 +4,7 @@ module.exports = defineConfig({
   viewportHeight: 1500,
   e2e: {
     baseUrl: 'http://localhost:8010/',
+    experimentalCspAllowList: true,
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -18,3 +18,17 @@ import './commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+
+beforeEach(() => {
+  // Intercept any breach of CSP rules
+  cy.intercept(
+    'POST', '/csp-report',
+    req => req.reply(200, { message: 'mocked response' })
+  ).as('cspReport')
+});
+
+afterEach(() => {
+  // There should have been no CSP breaches
+  cy.get('@cspReport.all').should('have.length', 0);
+});

--- a/request_a_govuk_domain/request/templates/cookies.html
+++ b/request_a_govuk_domain/request/templates/cookies.html
@@ -57,7 +57,7 @@
       </p>
 
       {% if GOOGLE_ANALYTICS_ID %}
-        <style>#cookies-analytics { display: none }</style>
+        <style nonce="{{request.csp_nonce}}">#cookies-analytics { display: none }</style>
         <div class="govuk-form-group govuk-!-margin-bottom-6" id="cookies-analytics">
           <fieldset class="govuk-fieldset" aria-describedby="hint-0c454062">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">

--- a/request_a_govuk_domain/settings.py
+++ b/request_a_govuk_domain/settings.py
@@ -264,7 +264,7 @@ SESSION_COOKIE_AGE = 24 * 60 * 60
 
 # Content Security Policy: only allow images, stylesheets and scripts from the
 # same origin as the HTML
-CSP_IMG_SRC = "'self'"
+CSP_IMG_SRC = "'self' data:"
 CSP_STYLE_SRC = "'self'"
 CSP_SCRIPT_SRC = "'self' https://*.googletagmanager.com"
 CSP_CONNECT_SRC = "'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com"
@@ -280,6 +280,14 @@ CSP_INCLUDE_NONCE_IN = [
 ]
 # Disable CSP for debug as it prevent the style sheets from loading on  localhost
 CSP_REPORT_ONLY = False
+
+# If we want to test CSP breaches we need to set a fake reporting URL, so the tests
+# check if it's been called.
+if "TEST_CSP" in os.environ:
+    CSP_REPORT_URI = (
+        "/csp-report"  # The URI doesn't exist but is intercepted by the test suite
+    )
+
 
 # HTTP Strict Transport Security settings
 # Tell browsers to only use HTTPS for a year


### PR DESCRIPTION
- we need to allow data URLs in inline CSS, as the django admin uses them. It's not a huge security risk, especially as the admin interface is behind a VPN

- this commit also adds a way to report any CSP breach when running end-to-end tests, by using CSP's reporting capability. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to