### PR TITLE
Send a 400 error if needed session data is missing, instead of a 500

### DIFF
--- a/cypress/e2e/errors-jump-around.cy.js
+++ b/cypress/e2e/errors-jump-around.cy.js
@@ -1,48 +1,44 @@
 import './base.cy'
 
 describe('Errors when user skips and jumps pages', () => {
-    it('Throws a 400 when user skips to success page', () => {
-
-        cy.goToRegistrantDetails()
-
-        cy.request({url: '/success', failOnStatusCode: false}).then(res => {
-            expect(res.status).to.eq(400)
-        })
+  it('Throws a 400 when user skips to success page', () => {
+    cy.goToRegistrantDetails()
+    cy.request({url: '/success', failOnStatusCode: false}).then(res => {
+      expect(res.status).to.eq(400)
     })
+  })
 
-    it('Throws a 400 when user goes back 6 pages after submitting', () => {
-        cy.goToConfirmation(1)
-        cy.get('.govuk-button#id_submit').click()
-        cy.checkPageTitleIncludes('Application submitted')
-        cy.go(-6)
-        cy.checkPageTitleIncludes('Invalid request')
-    })
+  it('Throws a 400 when user goes back 6 pages after submitting', () => {
+    cy.goToConfirmation(1)
+    cy.get('.govuk-button#id_submit').click()
+    cy.checkPageTitleIncludes('Application submitted')
+    cy.go(-6)
+    cy.checkPageTitleIncludes('Invalid request')
+  })
 
-    it('Throws a 400 when user goes back 4 pages after submitting', () => {
-        cy.goToConfirmation(1)
-        cy.get('.govuk-button#id_submit').click()
-        cy.checkPageTitleIncludes('Application submitted')
-        cy.go(-4)
-        cy.checkPageTitleIncludes('Invalid request')
-    })
+  it('Throws a 400 when user goes back 4 pages after submitting', () => {
+    cy.goToConfirmation(1)
+    cy.get('.govuk-button#id_submit').click()
+    cy.checkPageTitleIncludes('Application submitted')
+    cy.go(-4)
+    cy.checkPageTitleIncludes('Invalid request')
+  })
 
-    it('Throws a 400 when user goes back and forth after submitting', () => {
-        cy.goToConfirmation(1)
-        cy.get('.govuk-button#id_submit').click()
-        cy.checkPageTitleIncludes('Application submitted')
-        cy.go(-4)
-        cy.checkPageTitleIncludes('Invalid request')
-        cy.go(3)
-        cy.checkPageTitleIncludes('Invalid request')
-    })
+  it('Throws a 400 when user goes back and forth after submitting', () => {
+    cy.goToConfirmation(1)
+    cy.get('.govuk-button#id_submit').click()
+    cy.checkPageTitleIncludes('Application submitted')
+    cy.go(-4)
+    cy.checkPageTitleIncludes('Invalid request')
+    cy.go(3)
+    cy.checkPageTitleIncludes('Invalid request')
+  })
 
-    it('Throws a 400 when user goes back after submitting', () => {
-        cy.goToConfirmation(1)
-        cy.get('.govuk-button#id_submit').click()
-        cy.checkPageTitleIncludes('Application submitted')
-        cy.go('back')
-        cy.checkPageTitleIncludes('Invalid request')
-    })
-
-
+  it('Throws a 400 when user goes back after submitting', () => {
+    cy.goToConfirmation(1)
+    cy.get('.govuk-button#id_submit').click()
+    cy.checkPageTitleIncludes('Application submitted')
+    cy.go('back')
+    cy.checkPageTitleIncludes('Invalid request')
+  })
 })

--- a/cypress/e2e/errors-jump-around.cy.js
+++ b/cypress/e2e/errors-jump-around.cy.js
@@ -1,6 +1,13 @@
 import './base.cy'
 
 describe('Errors when user skips and jumps pages', () => {
+  it('Throws a 400 when user skips to registry page', () => {
+    cy.goToRegistrantType()
+    cy.request({url: '/registry-details', failOnStatusCode: false}).then(res => {
+      expect(res.status).to.eq(400)
+    })
+  })
+
   it('Throws a 400 when user skips to success page', () => {
     cy.goToRegistrantDetails()
     cy.request({url: '/success', failOnStatusCode: false}).then(res => {

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -5,7 +5,13 @@ from datetime import datetime
 
 from django.core.exceptions import BadRequest
 from django.db import transaction
-from django.http import HttpResponse, HttpRequest, FileResponse, HttpResponseNotFound
+from django.http import (
+    HttpResponse,
+    HttpRequest,
+    FileResponse,
+    HttpResponseNotFound,
+    HttpResponseBadRequest,
+)
 from django.shortcuts import render, redirect
 from django.urls import reverse_lazy
 from django.views import View
@@ -256,6 +262,15 @@ class RegistryDetailsView(FormView):
     template_name = "registry_details.html"
     form_class = RegistryDetailsForm
     success_url = reverse_lazy("confirm")
+
+    def dispatch(self, request, *args, **kwargs):
+        # Check that the session has the registrant type. Otherwise it
+        # means the user has skipped pages
+        try:
+            get_registration_data(request)["registrant_type"]
+        except KeyError:
+            return HttpResponseBadRequest("Bad request")
+        return super().dispatch(request, *args, **kwargs)
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()


### PR DESCRIPTION
The registry details page needs to know the registrant type in order to
display hint content. This commit checks if it's missing, and if
it is, causes a 400 error instead of a 500, since the user probably
jumped directly to the registry page and skipped the registrant type
selection.