### PR TITLE
Another catch with a 400 when user skips pages

### DIFF
--- a/cypress/e2e/errors-jump-around.cy.js
+++ b/cypress/e2e/errors-jump-around.cy.js
@@ -3,6 +3,12 @@ import './base.cy'
 describe('Errors when user skips and jumps pages', () => {
   it('Throws a 400 when user skips to registry page', () => {
     cy.goToRegistrantType()
+    cy.request({ url: '/registry-details', failOnStatusCode: false })
+      .its('status').should('eq', 400)
+  })
+
+  it('Throws a 400 when user skips to registry page', () => {
+    cy.goToRegistrantType()
     cy.request({url: '/registry-details', failOnStatusCode: false}).then(res => {
       expect(res.status).to.eq(400)
     })

--- a/request_a_govuk_domain/request/views.py
+++ b/request_a_govuk_domain/request/views.py
@@ -184,6 +184,15 @@ class DomainConfirmationView(FormView):
     template_name = "domain_confirmation.html"
     form_class = DomainConfirmationForm
 
+    def dispatch(self, request, *args, **kwargs):
+        # Check that the session has the domain. Otherwise it
+        # means the user has skipped pages and we should return 400
+        try:
+            get_registration_data(request)["domain_name"]
+        except KeyError:
+            return HttpResponseBadRequest("Bad request")
+        return super().dispatch(request, *args, **kwargs)
+
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         session = self.request.session.get(REGISTRATION_DATA, {})


### PR DESCRIPTION
This time, the user shouldn't be allowed to jump straight to the domain name confirmation page before the domain name page.