### PR TITLE
Add the service name below the header

### DIFF
--- a/request_a_govuk_domain/request/templates/base.html
+++ b/request_a_govuk_domain/request/templates/base.html
@@ -106,6 +106,19 @@
   </div>
 </header>
 
+<section aria-label="Service information" class="govuk-service-navigation"
+  data-module="govuk-service-navigation">
+  <div class="govuk-width-container">
+    <div class="govuk-service-navigation__container">
+      <span class="govuk-service-navigation__service-name">
+        <a href="#" class="govuk-service-navigation__link">
+          Get approval to use a .gov.uk domain name
+        </a>
+      </span>
+    </div>
+  </div>
+</section>
+
   {% endblock %}
 
   {% block phase_banner %}


### PR DESCRIPTION
Part of the new design rules:

https://design-system.service.gov.uk/components/header/#govuk-header-with-service-name