### PR TITLE
Add /tmp VOLUME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ ENV DOMAIN_NAME=http://localhost:2010
 
 RUN /app/manage.py collectstatic --no-input
 
+VOLUME /tmp
 RUN mkdir /var/run/request_a_govuk_domain && \
     chown govuk_domain:govuk_domain /var/run/request_a_govuk_domain
 


### PR DESCRIPTION
This is needed for fixing Security Hub findings - "ECS containers should be limited to read-only access to root filesystems"

To fix the above we set the container's readonly_root_filesystem to true and we enable read-write only for the volumes which are needed for functioning of the container.

The above setting happens in AWS, however if a folder already exists in the docker image, e.g. /tmp, which comes from amazonlinux:2023 image then it needs to be created as VOLUME so that container makes /tmp as read-write before locking the the file system to read only.

/tmp is needed as read-write because in our case we start to see errors for directories like '/tmp/celerybeat-schedule' in Sentry.